### PR TITLE
[GBT-28] Feat/add judge scanner for participant

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,13 @@
     "@phosphor-icons/react": "^2.1.7",
     "@prisma/client": "^6.1.0",
     "bcrypt": "^5.1.1",
+    "html5-qrcode": "^2.3.8",
     "next": "15.1.2",
     "next-auth": "^4.24.11",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hot-toast": "^2.4.1",
+    "sqids": "^0.3.0",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -111,14 +111,14 @@ enum ParticipantStatus {
 }
 
 model User {
-  id          Int          @id @default(autoincrement())
-  name        String
-  email       String       @unique
-  rut         String       @unique
-  role        Role
-  judge       Judge[]
-  participant Participant?
-  admin       Admin?
+  id           Int         @id @default(autoincrement())
+  name         String
+  email        String      @unique
+  rut          String      @unique
+  role         Role
+  judge        Judge[]
+  participant  Participant[]
+  admin        Admin?
 }
 
 enum Role {

--- a/src/app/actions/judge.ts
+++ b/src/app/actions/judge.ts
@@ -1,14 +1,52 @@
 'use server';
 
-import { SubmissionResult } from '@conform-to/react';
-import { User } from '@prisma/client';
+import { SubmissionResult } from "@conform-to/react";
+import { Competition, User } from "@prisma/client";
 import { revalidatePath } from 'next/cache';
 
 import { ManageJudgeSchema } from '@/app/dashboard/competitions/manage/[competitionId]/judges/schemas/manageJudgesSchema';
 import { getUserFromSession } from '@/lib/auth';
-import { findJudgeByUserIdAndCompetitionId, linkJudgeWithUser, removeJudgeFromCompetitionById, removeJudgeFromProblem } from '@/lib/db/judge';
+import { getCompetitionsByJudgeId } from "@/lib/db/competition";
+import { getJudgeByRut, findJudgeByUserIdAndCompetitionId, linkJudgeWithUser, removeJudgeFromCompetitionById, removeJudgeFromProblem } from "@/lib/db/judge";
+import { getOrganizerNameById } from "@/lib/db/organizer";
 import { updateProblemJudge } from '@/lib/db/problem';
 import { createJudgeUser, findUserByEmailOrRut } from '@/lib/db/user';
+
+
+type JudgeValidationResult = SubmissionResult & {
+  data?: { 
+    competitions: Competition[];
+    organizerName: string;
+    judgeId: number;
+  };
+};
+
+export async function findJudge(_prevState: unknown, formData: FormData): Promise<JudgeValidationResult> {
+  const rut = formData.get('rut') as string;
+  const judge = await getJudgeByRut(rut);
+
+  if (!judge) {
+    return {
+      status: 'error',
+      error: { message: ['No se encontró el juez'] },
+    };
+  }
+
+  const competitions = await getCompetitionsByJudgeId(judge.id, judge.organizerId);
+  const organizerName = await getOrganizerNameById(judge.organizerId);
+
+  if (!organizerName) {
+    return {
+      status: 'error',
+      error: { message: ['No se pudo obtener el nombre del organizador'] },
+    };
+  }
+  
+  return {
+    status: 'success',
+    data: { competitions, organizerName, judgeId: judge.id },
+  };
+}
 
 interface AssignJudgeResult {
   status: 'success' | 'error';

--- a/src/app/actions/judge.ts
+++ b/src/app/actions/judge.ts
@@ -11,7 +11,7 @@ import { getJudgeByRut, findJudgeByUserIdAndCompetitionId, linkJudgeWithUser, re
 import { getOrganizerNameById } from "@/lib/db/organizer";
 import { updateProblemJudge } from '@/lib/db/problem';
 import { createJudgeUser, findUserByEmailOrRut } from '@/lib/db/user';
-
+import { normalizeRut } from "@/utils/rut";
 
 type JudgeValidationResult = SubmissionResult & {
   data?: { 
@@ -22,7 +22,7 @@ type JudgeValidationResult = SubmissionResult & {
 };
 
 export async function findJudge(_prevState: unknown, formData: FormData): Promise<JudgeValidationResult> {
-  const rut = formData.get('rut') as string;
+  const rut = normalizeRut(formData.get('rut') as string);
   const judge = await getJudgeByRut(rut);
 
   if (!judge) {

--- a/src/app/actions/participant.ts
+++ b/src/app/actions/participant.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import { SubmissionResult } from "@conform-to/react";
+
+import { isJudgeOfParticipant } from "@/lib/db/judge";
+import { findParticipantById } from "@/lib/db/participant";
+import { decodeIdInBloat } from "@/lib/encoder";
+
+type ParticipantSearchResult = SubmissionResult & {
+  data?: { id: number };
+};
+
+export async function searchParticipant(_prevState: unknown, formData: FormData, competitionId: number, judgeId: number): Promise<ParticipantSearchResult> {
+  const participantCode = formData.get('participantCode') as string;
+  
+  try {
+    const participantId = decodeIdInBloat(participantCode);
+    const participant = await findParticipantById(participantId);
+    
+    if (!participant) {
+      return {
+        status: 'error',
+        error: { message: ['No se encontró ningún participante con ese código'] },
+      };
+    }
+    
+    const isValidJudge = await isJudgeOfParticipant(judgeId, participantId, competitionId);
+
+    if (!isValidJudge) {
+      return {
+        status: 'error',
+        error: { message: ['No tienes permisos para ver este participante'] },
+      };
+    }
+
+    return {
+      status: 'success',
+      data: { id: participant.id },
+    };
+  } catch (error) {
+    return {
+      status: 'error',
+      error: { message: [`Error al buscar participante: ${error as string}`] },
+    };
+  }
+} 

--- a/src/app/api/auth/signup/route.ts
+++ b/src/app/api/auth/signup/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 
 import { signupSchema } from '@/app/signup/schemas/signupSchema';
 import prisma from '@/lib/db/prisma';
+import { normalizeRut } from '@/utils/rut';
 
 export async function POST(request: Request) {
   try {
@@ -17,12 +18,13 @@ export async function POST(request: Request) {
     }
 
     const { name, email, password, rut, organizerName } = signupSchema.parse(body);
+    const normalizedRut = normalizeRut(rut);
 
     const existingUser = await prisma.user.findFirst({
       where: {
         OR: [
           { email },
-          { rut },
+          { rut: normalizedRut },
         ],
       },
     });
@@ -60,7 +62,7 @@ export async function POST(request: Request) {
         name,
         email,
         role: Role.ADMIN,
-        rut,
+        rut: normalizedRut,
       },
     });
 

--- a/src/app/dashboard/admin/manage/schemas/createAdminSchema.ts
+++ b/src/app/dashboard/admin/manage/schemas/createAdminSchema.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { cleanRut, validateRut, formatRut } from '@/utils/rutValidator';
+import { cleanRut, validateRut, formatRut } from '@/utils/rut';
 
 export const CreateAdminSchema = z.object({
   name: z.string({ message: "Nombre requerido" })

--- a/src/app/dashboard/competitions/manage/[competitionId]/judges/schemas/manageJudgesSchema.tsx
+++ b/src/app/dashboard/competitions/manage/[competitionId]/judges/schemas/manageJudgesSchema.tsx
@@ -1,6 +1,6 @@
 import { z } from "zod";
 
-import { cleanRut, validateRut, formatRut } from "@/utils/rutValidator";
+import { cleanRut, validateRut, formatRut } from "@/utils/rut";
 
 export const ManageJudgeSchema = z.object({
   competitionId: z.number(),

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -2,7 +2,7 @@ import { redirect } from "next/navigation";
 
 import Navbar from "@/components/ui/Navbar";
 import { getUserFromSession, isSuperAdmin } from "@/lib/auth";
-import { getOrganizerName } from "@/lib/db/organizer";
+import { getOrganizerNameById } from "@/lib/db/organizer";
 
 export default async function DashboardLayout({ children }: { children: React.ReactNode }) {
   const user = await getUserFromSession();
@@ -11,7 +11,7 @@ export default async function DashboardLayout({ children }: { children: React.Re
   }
 
   const superAdmin = await isSuperAdmin(user)
-  const organizerName = await getOrganizerName(user.organizerId);
+  const organizerName = await getOrganizerNameById(user.organizerId);
 
   if (!organizerName) {
     throw new Error("No se pudo obtener el nombre del organizador");

--- a/src/app/judge/competitions/show/[encodedJudgeId]/[encodedCompetitionId]/components/ParticipantSearchForm.tsx
+++ b/src/app/judge/competitions/show/[encodedJudgeId]/[encodedCompetitionId]/components/ParticipantSearchForm.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useForm } from '@conform-to/react';
+import { parseWithZod } from '@conform-to/zod';
+import { useRouter } from 'next/navigation';
+import React, { useState, useEffect, useActionState } from 'react';
+import { toast } from 'react-hot-toast';
+
+import { searchParticipant } from '@/app/actions/participant';
+import FormInput from '@/components/ui/FormInput';
+import QrScanner from '@/components/ui/QrScanner';
+import SubmitButton from '@/components/ui/SubmitButton';
+import { encodeIdInBloat } from '@/lib/encoder';
+
+import { ParticipantSearchSchema } from '../schemas/participantSearchSchema';
+
+export default function ParticipantSearchForm({ competitionId, judgeId }: { competitionId: number, judgeId: number }) {
+  const [showScanner, setShowScanner] = useState(false);
+  const [participantCode, setParticipantCode] = useState('');
+  const [lastResult, formAction] = useActionState(
+    async (_state: unknown | undefined, formData: FormData) => searchParticipant(undefined, formData, competitionId, judgeId),
+    undefined,
+  );
+  const router = useRouter();
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: ParticipantSearchSchema });
+    },
+    shouldValidate: 'onBlur',
+    shouldRevalidate: 'onInput',
+  });
+
+  useEffect(() => {
+    if (lastResult?.status === 'success' && lastResult.data) {
+      toast.success('Participante encontrado');
+      router.push(`/judge/competitions/show/${encodeIdInBloat(competitionId)}/${encodeIdInBloat(judgeId)}/participant/${encodeIdInBloat(lastResult.data.id)}`);
+    } else if (lastResult?.status === 'error') {
+      const errorMessage = lastResult.error?.message?.[0] || 'Error al buscar participante';
+      toast.error(errorMessage);
+    }
+  }, [competitionId, judgeId, lastResult, router]);
+
+  function handleQrSuccess(result: string) {
+    setParticipantCode(result);
+    setShowScanner(false);
+    fields.participantCode.value = result;
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="card bg-base-100 shadow-xl">
+        <div className="card-body">
+          <h2 className="card-title mb-6 text-2xl">Buscar Participante</h2>
+
+          <div className="flex flex-col gap-4">
+            <button
+              className="btn btn-primary"
+              onClick={() => setShowScanner(!showScanner)}
+            >
+              {showScanner ? 'Cerrar Scanner' : 'Escanear QR'}
+            </button>
+
+            {showScanner && (
+              <div className="my-4">
+                <QrScanner onScan={handleQrSuccess} />
+              </div>
+            )}
+
+            <div className="divider">O</div>
+
+            <form
+              id={form.id}
+              onSubmit={form.onSubmit}
+              action={formAction}
+              className="space-y-4"
+            >
+              <FormInput
+                label="Código del Participante"
+                name={fields.participantCode.name}
+                type="text"
+                placeholder="Ingrese el código del participante"
+                required
+                value={participantCode}
+                onChange={(e) => setParticipantCode(e.target.value)}
+                errors={fields.participantCode.errors}
+              />
+
+              <SubmitButton
+                label="Buscar Participante"
+                loadingLabel="Buscando Participante"
+              />
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+} 

--- a/src/app/judge/competitions/show/[encodedJudgeId]/[encodedCompetitionId]/page.tsx
+++ b/src/app/judge/competitions/show/[encodedJudgeId]/[encodedCompetitionId]/page.tsx
@@ -1,0 +1,16 @@
+import { decodeIdInBloat } from "@/lib/encoder";
+
+import ParticipantSearchForm from "./components/ParticipantSearchForm";
+
+type ShowCompetitionPageProps = Promise<{ encodedCompetitionId: string, encodedJudgeId: string }>;
+
+export default async function ShowCompetitionPage(props: { params: ShowCompetitionPageProps }) {
+  const { encodedCompetitionId, encodedJudgeId } = await props.params;
+  const competitionId = decodeIdInBloat(encodedCompetitionId);
+  const judgeId = decodeIdInBloat(encodedJudgeId);
+  return (
+    <div>
+      <ParticipantSearchForm competitionId={competitionId} judgeId={judgeId} />
+    </div>
+  );
+}

--- a/src/app/judge/competitions/show/[encodedJudgeId]/[encodedCompetitionId]/schemas/participantSearchSchema.tsx
+++ b/src/app/judge/competitions/show/[encodedJudgeId]/[encodedCompetitionId]/schemas/participantSearchSchema.tsx
@@ -1,0 +1,9 @@
+import { z } from "zod";
+
+export const ParticipantSearchSchema = z.object({
+  participantCode: z
+    .string({ message: "Código requerido" })
+    .min(5, { message: "El código debe tener al menos 5 caracteres" }),
+});
+
+export type ParticipantSearchFormData = z.infer<typeof ParticipantSearchSchema>; 

--- a/src/app/judge/components/CompetitionCodeModal.tsx
+++ b/src/app/judge/components/CompetitionCodeModal.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import Dialog from '@/components/Dialog';
+
+interface CompetitionCodeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (code: string) => void;
+}
+
+export default function CompetitionCodeModal({ isOpen, onClose, onSubmit }: CompetitionCodeModalProps) {
+  const [competitionCode, setCompetitionCode] = useState('');
+  const [errorMessage, setErrorMessage] = useState('');
+
+  function handleCodeSubmit() {
+    if (!competitionCode.trim()) {
+      setErrorMessage('Por favor ingrese un código');
+      return;
+    }
+    onSubmit(competitionCode);
+  }
+
+  const actions = (
+    <>
+      <button onClick={handleCodeSubmit} className="btn btn-primary">
+        Verificar
+      </button>
+      <button onClick={onClose} className="btn">
+        Cancelar
+      </button>
+    </>
+  );
+
+  return (
+    <Dialog
+      id="competition-code-modal"
+      title="Ingresar Código de Competencia"
+      isOpen={isOpen}
+      onClose={onClose}
+      actions={actions}
+    >
+      <input
+        type="text"
+        value={competitionCode}
+        onChange={(e) => setCompetitionCode(e.target.value)}
+        className="input input-bordered w-full"
+        placeholder="Código de Competencia"
+      />
+      {errorMessage && <p className="mt-2 text-red-500">{errorMessage}</p>}
+    </Dialog>
+  );
+}

--- a/src/app/judge/components/FoundCompetitionsList.tsx
+++ b/src/app/judge/components/FoundCompetitionsList.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { Competition } from "@prisma/client";
+
+type FoundCompetitionsListProps = {
+  competitions: Competition[];
+  organizerName: string;
+  handleOpenModal: (competition: Competition) => void;
+}
+
+export function FoundCompetitionsList({ competitions, organizerName, handleOpenModal }: FoundCompetitionsListProps) {
+  return (
+    <>
+      {competitions.length > 0 && (
+        <div className="mt-8">
+          <h3 className="mb-4 text-xl font-semibold">Competencias Encontradas</h3>
+          <div className="space-y-4">
+            {competitions.map((competition) => ( competition.date >= new Date() &&
+              <div key={competition.id} className="card bg-base-200">
+                <div className="card-body">
+                  <h4 className="card-title">{competition.name}</h4>
+                  <p><strong>Organizador:</strong> {organizerName}</p>
+                  <p><strong>Ubicación:</strong> {competition.location}</p>
+                  <p><strong>Fecha:</strong> {new Date(competition.date).toLocaleDateString('es-ES', { day: '2-digit', month: '2-digit', year: 'numeric' })}</p>
+                  <div className="card-actions justify-end">
+                    <button onClick={() => handleOpenModal(competition)} className='btn btn-primary'>
+                        Ingresar
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/judge/components/JudgeValidationForm.tsx
+++ b/src/app/judge/components/JudgeValidationForm.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useForm } from '@conform-to/react';
+import { parseWithZod } from '@conform-to/zod';
+import { Competition } from '@prisma/client';
+import { useRouter } from 'next/navigation';
+import React, { useActionState } from 'react';
+import { toast } from 'react-hot-toast';
+
+import { findJudge } from '@/app/actions/judge';
+import { RutInput } from '@/components/RutInput';
+import SubmitButton from '@/components/ui/SubmitButton';
+import { encodeIdInBloat } from '@/lib/encoder';
+
+import CompetitionCodeModal from './CompetitionCodeModal';
+import { FoundCompetitionsList } from './FoundCompetitionsList';
+import { JudgeValidationSchema } from '../schemas/judgeValidationSchema';
+
+export default function JudgeValidationForm() {
+  const router = useRouter();
+  const [lastResult, formAction] = useActionState(findJudge, undefined);
+  const [competitions, setCompetitions] = React.useState<Competition[]>([]);
+  const [organizerName, setOrganizerName] = React.useState<string>('');
+  const [judgeId, setJudgeId] = React.useState<number | null>(null);
+  const [isModalOpen, setIsModalOpen] = React.useState(false);
+  const [selectedCompetition, setSelectedCompetition] = React.useState<Competition | null>(null);
+
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate({ formData }) {
+      return parseWithZod(formData, { schema: JudgeValidationSchema });
+    },
+    shouldValidate: 'onBlur',
+    shouldRevalidate: 'onInput',
+  });
+
+  React.useEffect(() => {
+    if (lastResult?.status === 'success') {
+      toast.success('Validación exitosa');
+      setCompetitions(lastResult.data?.competitions || []);
+      setOrganizerName(lastResult.data?.organizerName || '');
+      setJudgeId(lastResult.data?.judgeId || null);
+    } else if (lastResult?.status === 'error') {
+      const errorMessage = lastResult.error?.message?.[0] || 'No se encontró el juez';
+      toast.error(errorMessage);
+    }
+  }, [lastResult, router]);
+
+  function handleCloseModal() {
+    setIsModalOpen(false);
+  }
+
+  function handleOpenModal(competition: Competition) {
+    setSelectedCompetition(competition);
+    setIsModalOpen(true);
+  }
+
+  function handleCodeSubmit(code: string) {
+    if (selectedCompetition) {
+      if (selectedCompetition.code === code) {
+        toast.success('Competencia ingresada correctamente');
+        if (judgeId) {
+          router.push(`/judge/competitions/show/${encodeIdInBloat(judgeId)}/${encodeIdInBloat(selectedCompetition.id)}`);
+        }
+      } else {
+        toast.error('Código incorrecto');
+      }
+    }
+  }
+
+  return (
+    <div className="container mx-auto p-6">
+      <div className="card bg-base-100 shadow-xl">
+        <div className="card-body">
+          <h2 className="card-title mb-6 text-2xl">Validación de Juez</h2>
+          
+          <form id={form.id} onSubmit={form.onSubmit} action={formAction} className="space-y-4">
+            <div className="form-control">
+              <RutInput
+                errors={fields.rut.errors}
+              />
+            </div>
+
+            <SubmitButton
+              label="Buscar"
+              loadingLabel="Buscando..."
+            />
+          </form>
+        </div>
+
+        <FoundCompetitionsList competitions={competitions} organizerName={organizerName} handleOpenModal={handleOpenModal}/>
+        
+        {isModalOpen && (
+          <CompetitionCodeModal
+            isOpen={isModalOpen}
+            onClose={handleCloseModal}
+            onSubmit={handleCodeSubmit}
+          />
+        )}
+      </div>
+    </div>
+  );
+} 

--- a/src/app/judge/page.tsx
+++ b/src/app/judge/page.tsx
@@ -1,0 +1,5 @@
+import JudgeValidationForm from './components/JudgeValidationForm';
+
+export default async function WelcomePage() {
+  return <JudgeValidationForm />;
+}

--- a/src/app/judge/schemas/judgeValidationSchema.tsx
+++ b/src/app/judge/schemas/judgeValidationSchema.tsx
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+import { cleanRut, validateRut, formatRut } from "@/utils/rut";
+
+export const JudgeValidationSchema = z.object({
+  rut: z.string({ message: "RUT requerido" })
+    .min(8, { message: "El RUT debe tener al menos 8 caracteres" })
+    .transform(cleanRut)
+    .refine(
+      (val) => validateRut(val),
+      { message: "RUT inválido" },
+    )
+    .transform(formatRut),
+});
+
+export type JudgeValidationFormData = z.infer<typeof JudgeValidationSchema>; 

--- a/src/app/signup/components/SignupForm.tsx
+++ b/src/app/signup/components/SignupForm.tsx
@@ -8,6 +8,7 @@ import toast from 'react-hot-toast';
 import { RutInput } from '@/components/RutInput';
 import FormInput from '@/components/ui/FormInput';
 import SubmitButton from '@/components/ui/SubmitButton';
+import { normalizeRut } from '@/utils/rut';
 
 import { signupSchema, type SignupFormData } from '../schemas/signupSchema';
 
@@ -25,7 +26,7 @@ export function SignupForm() {
       email: formData.get('email') as string,
       password: formData.get('password') as string,
       confirmPassword: formData.get('confirmPassword') as string,
-      rut: formData.get('rut') as string,
+      rut: normalizeRut(formData.get('rut') as string),
       organizerName: formData.get('organizerName') as string,
     };
 

--- a/src/app/signup/schemas/signupSchema.ts
+++ b/src/app/signup/schemas/signupSchema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { cleanRut, validateRut, formatRut } from '@/utils/rutValidator';
+import { cleanRut, validateRut, formatRut } from '@/utils/rut';
 
 export const signupSchema = z
   .object({

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+
+interface DialogProps {
+  id: string;
+  title: string;
+  children: React.ReactNode;
+  actions?: React.ReactNode;
+  isOpen?: boolean;
+  onClose?: () => void;
+}
+
+export default function Dialog({ id, title, children, actions, isOpen, onClose }: DialogProps) {
+  return (
+    <dialog id={id} className={`modal ${isOpen ? 'modal-open' : ''}`}>
+      <div className="modal-box">
+        <h3 className="text-lg font-bold">{title}</h3>
+        <div className="mt-4">{children}</div>
+        <div className="modal-action">
+          {actions || (
+            <button type="button" className="btn" onClick={onClose}>
+              Cerrar
+            </button>
+          )}
+        </div>
+      </div>
+    </dialog>
+  );
+} 

--- a/src/components/RutInput.tsx
+++ b/src/components/RutInput.tsx
@@ -29,7 +29,7 @@ export function RutInput({ errors }: RutInputProps) {
     <FormInput
       name="rut"
       type="text"
-      placeholder="RUT (ej: 12.345.678-9)"
+      placeholder="ej: 12.345.678-9"
       errors={errors}
       onChange={handleRutChange}
       maxLength={12}

--- a/src/components/RutInput.tsx
+++ b/src/components/RutInput.tsx
@@ -27,6 +27,7 @@ export function RutInput({ errors }: RutInputProps) {
 
   return (
     <FormInput
+      label="RUT"
       name="rut"
       type="text"
       placeholder="ej: 12.345.678-9"

--- a/src/components/ui/QrScanner.tsx
+++ b/src/components/ui/QrScanner.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { Html5QrcodeScanner, Html5QrcodeSupportedFormats } from 'html5-qrcode';
+import React, { useEffect, useRef } from 'react';
+
+const scanRegionId = "html5qr-code-full-region";
+
+interface QrScannerProps {
+  onScan: (result: string) => void;
+}
+
+type ScanConfig = {
+  fps: number;
+  qrbox: { width: number; height: number };
+  aspectRatio: number;
+  formatsToSupport: Html5QrcodeSupportedFormats[];
+  experimentalFeatures: {
+    useBarCodeDetectorIfSupported: boolean;
+  };
+};
+
+export default function QrScanner({ onScan }: QrScannerProps) {
+  const scannerRef = useRef<Html5QrcodeScanner | null>(null);
+  const memoizedScanHandler = useRef(onScan);
+
+  useEffect(() => {
+    memoizedScanHandler.current = onScan;
+  }, [onScan]);
+
+  useEffect(() => {
+    const config: ScanConfig = {
+      fps: 10,
+      qrbox: { width: 250, height: 250 },
+      aspectRatio: 1.0,
+      formatsToSupport: [Html5QrcodeSupportedFormats.QR_CODE],
+      experimentalFeatures: {
+        useBarCodeDetectorIfSupported: true,
+      },
+    };
+
+    if (scannerRef.current === null) {
+      scannerRef.current = new Html5QrcodeScanner(
+        scanRegionId,
+        config,
+        false,
+      );
+    }
+
+    function qrCodeSuccessCallback(decodedText: string) {
+      memoizedScanHandler.current(decodedText);
+      scannerRef.current?.clear();
+    }
+
+    setTimeout(() => {
+      const container = document.getElementById(scanRegionId);
+      if (scannerRef.current && container?.innerHTML === "") {
+        scannerRef.current.render(qrCodeSuccessCallback, undefined);
+      }
+    }, 0);
+
+    return () => {
+      if (scannerRef.current) {
+        scannerRef.current.clear();
+      }
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-col items-center">
+      <div
+        id={scanRegionId}
+        className="mx-auto w-full max-w-md overflow-hidden rounded-lg border border-purple-500 bg-gray-900 p-4 shadow-xl"
+      />
+      <style jsx global>{`
+        #${scanRegionId} {
+          min-height: 300px;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          justify-content: center;
+        }
+        #${scanRegionId} video {
+          border-radius: 0.5rem;
+          max-width: 100%;
+          height: auto;
+        }
+        #html5-qrcode-button-camera-permission {
+          background: #8B5CF6 !important;
+          color: white !important;
+          border: none !important;
+          padding: 0.5rem 1rem !important;
+          border-radius: 0.375rem !important;
+          margin: 0.5rem !important;
+          cursor: pointer !important;
+          font-size: 1rem !important;
+        }
+        #html5-qrcode-button-camera-start,
+        #html5-qrcode-button-camera-stop {
+          background: #8B5CF6 !important;
+          color: white !important;
+          border: none !important;
+          padding: 0.5rem 1rem !important;
+          border-radius: 0.375rem !important;
+          margin: 0.5rem !important;
+          cursor: pointer !important;
+          font-size: 1rem !important;
+        }
+        #html5-qrcode-anchor-scan-type-change {
+          display: none !important;
+        }
+        .html5-qrcode-element {
+          background: transparent !important;
+          border: none !important;
+        }
+        #html5qr-code-full-region__scan_region {
+          background: transparent !important;
+          position: relative !important;
+          min-height: 200px !important;
+          display: flex !important;
+          align-items: center !important;
+          justify-content: center !important;
+        }
+        #html5qr-code-full-region__dashboard_section {
+          padding: 1rem !important;
+          background: transparent !important;
+          border: none !important;
+          text-align: center !important;
+        }
+        #html5qr-code-full-region__header_message {
+          color: white !important;
+          margin-bottom: 1rem !important;
+        }
+        .html5-qrcode-element select {
+          background: #374151 !important;
+          color: white !important;
+          border: 1px solid #6B7280 !important;
+          border-radius: 0.375rem !important;
+          padding: 0.5rem !important;
+          margin: 0.5rem !important;
+        }
+        #html5qr-code-full-region__scan_region img {
+          filter: invert(1) !important;
+        }
+        #html5qr-code-full-region__scan_region svg {
+          fill: white !important;
+          color: white !important;
+        }
+        #html5-qrcode-button-camera-start {
+          font-size: 0 !important;
+        }
+        #html5-qrcode-button-camera-start::after {
+          content: 'Iniciar escaneo' !important;
+          font-size: 1rem !important;
+        }
+
+        #html5-qrcode-button-camera-stop {
+          font-size: 0 !important;
+        }
+        #html5-qrcode-button-camera-stop::after {
+          content: 'Detener escaneo' !important;
+          font-size: 1rem !important;
+        }
+
+        #html5-qrcode-button-camera-permission {
+          font-size: 0 !important;
+        }
+        #html5-qrcode-button-camera-permission::after {
+          content: 'Permitir cámara' !important;
+          font-size: 1rem !important;
+        }
+      `}</style>
+    </div>
+  );
+} 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,7 +30,6 @@ export const authOptions: NextAuthOptions = {
       credentials: {
         email: { label: 'Email', type: 'email' },
         password: { label: 'Password', type: 'password' },
-        rut: { label: 'Rut', type: 'text' },
       },
 
       async authorize(credentials) {
@@ -40,7 +39,6 @@ export const authOptions: NextAuthOptions = {
         const existingUser = await prisma.user.findFirst({
           where: {
             email: credentials.email.toLowerCase(),
-            rut: credentials.rut,
           },
           include: {
             admin: true,

--- a/src/lib/db/competition.ts
+++ b/src/lib/db/competition.ts
@@ -74,6 +74,19 @@ export async function getLastNCompetitionsForOrganizer(organizerId: number, n: n
   });
 }
 
+export async function getCompetitionsByJudgeId(judgeId: number, organizerId: number) {
+  return await prisma.competition.findMany({
+    where: {
+      judges: {
+        some: {
+          id: judgeId,
+        },
+      },
+      organizerId,
+    },
+  });
+}
+
 export async function getCompetitionsForOrganizerId(organizerId: number) {
   return await prisma.competition.findMany({
     where: {

--- a/src/lib/db/judge.ts
+++ b/src/lib/db/judge.ts
@@ -51,3 +51,29 @@ export async function removeJudgeFromProblem(problemId: number, judgeId: number)
     },
   });
 }
+
+export async function getJudgeByRut(rut: string) {
+  const users = await prisma.user.findMany({
+    where: {
+      rut,
+    },
+  });
+
+  if (users.length === 0) {
+    return null;
+  }
+
+  for (const user of users) {
+    const judge = await prisma.judge.findFirst({
+      where: {
+        userId: user.id,
+      },
+    });
+
+    if (judge) {
+      return judge;
+    }
+  }
+
+  return null;
+}

--- a/src/lib/db/judge.ts
+++ b/src/lib/db/judge.ts
@@ -77,3 +77,17 @@ export async function getJudgeByRut(rut: string) {
 
   return null;
 }
+
+export async function isJudgeOfParticipant(judgeId: number, participantId: number, competitionId: number) {
+  const competition = await prisma.competition.findFirst({
+    where: {
+      AND: [
+        { id: competitionId },
+        { judges: { some: { id: judgeId } } },
+        { participants: { some: { id: participantId } } },
+      ],
+    },
+  });
+
+  return !!competition;
+}

--- a/src/lib/db/organizer.ts
+++ b/src/lib/db/organizer.ts
@@ -1,6 +1,6 @@
 import prisma from "./prisma";
 
-export async function getOrganizerName(organizerId: number) {
+export async function getOrganizerNameById(organizerId: number) {
   const organizer = await prisma.organizer.findUnique({
     where: { id: organizerId },
   });

--- a/src/lib/db/participant.ts
+++ b/src/lib/db/participant.ts
@@ -53,3 +53,17 @@ export async function updateParticipantStatuses(updates: { id: number, status: P
   }));
   await Promise.all(updatePromises);
 }
+
+export async function findParticipantById(id: number) {
+  const participant = await prisma.participant.findUnique({
+    where: {
+      id,
+    },
+    include: {
+      competition: true,
+      problems: true,
+    },
+  });
+
+  return participant;
+}

--- a/src/lib/encoder.ts
+++ b/src/lib/encoder.ts
@@ -1,0 +1,16 @@
+import Sqids from 'sqids'
+
+const sqids = new Sqids({
+  minLength: 5,
+  alphabet: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
+})
+
+export function encodeIdInBloat(id: number) {
+  const encoded = sqids.encode([id])
+  return encoded;
+}
+
+export function decodeIdInBloat(encoded: string) {
+  const numbers = sqids.decode(encoded)
+  return numbers[0]
+}

--- a/src/utils/rut.ts
+++ b/src/utils/rut.ts
@@ -32,3 +32,7 @@ export function validateRut(rut: string): boolean {
   
   return calculatedDv === dv.toLowerCase();
 }
+
+export function normalizeRut(rut: string): string {
+  return rut.replace(/\./g, '').toLowerCase();
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -588,6 +588,7 @@
     tslib "^2.6.2"
 
 "@babel/runtime@^7.20.13":
+"@babel/runtime@^7.20.13":
   version "7.26.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.0.tgz#8600c2f595f277c60815256418b85356a65173c1"
   integrity sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==
@@ -596,19 +597,19 @@
 
 "@conform-to/dom@1.2.2":
   version "1.2.2"
-  resolved "https://registry.npmjs.org/@conform-to/dom/-/dom-1.2.2.tgz"
+  resolved "https://registry.yarnpkg.com/@conform-to/dom/-/dom-1.2.2.tgz#2c5d5b24d0275ef220075c6ec479f65d1a00ffbe"
   integrity sha512-f05EClpNP31o6lX4LYmmLqgsiTOHdGfY7z2XXK6U6rRp+EtxrkUBdrFlIGsfkf7e9AFO19h3/Cb/cXHVd1k1FA==
 
 "@conform-to/react@^1.2.2":
   version "1.2.2"
-  resolved "https://registry.npmjs.org/@conform-to/react/-/react-1.2.2.tgz"
+  resolved "https://registry.yarnpkg.com/@conform-to/react/-/react-1.2.2.tgz#f7db3a73670fdefac1ff20203c63272377e33cf6"
   integrity sha512-1JBECb3NKi5/IlexaYLgnAxGJ55MRuO2sEQ10cJfUK2bfltNbTIQnYUDG6pU886A4lda/q6UH/adPsjiB/4Gkg==
   dependencies:
     "@conform-to/dom" "1.2.2"
 
 "@conform-to/zod@^1.2.2":
   version "1.2.2"
-  resolved "https://registry.npmjs.org/@conform-to/zod/-/zod-1.2.2.tgz"
+  resolved "https://registry.yarnpkg.com/@conform-to/zod/-/zod-1.2.2.tgz#ca33c705d19dded4e92cd7c15a7b5e2ed09fcdc9"
   integrity sha512-mNCzh0XsF2vhCtD8bfHYMYayEJ9dP6/KsGjmq8DFcO1ykDTNQZwfi1MIm4evGYVempSS3poYr4xZjd7cXEbtaw==
   dependencies:
     "@conform-to/dom" "1.2.2"
@@ -2905,6 +2906,11 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+html5-qrcode@^2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/html5-qrcode/-/html5-qrcode-2.3.8.tgz#0b0cdf7a9926cfd4be530e13a51db47592adfa0d"
+  integrity sha512-jsr4vafJhwoLVEDW3n1KvPnCCXWaQfRng0/EEYk1vNcQGcG/htAdhJX0be8YyqMoSz7+hZvOZSTAepsabiuhiQ==
+
 https-proxy-agent@^5.0.0:
   version "5.0.1"
   resolved "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz"
@@ -4085,6 +4091,11 @@ source-map-js@^1.0.2, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
+sqids@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/sqids/-/sqids-0.3.0.tgz#969eabe54a362682e44cb73fce2bfea84e504dec"
+  integrity sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==
 
 stable-hash@^0.0.4:
   version "0.0.4"


### PR DESCRIPTION
## Descripción

Se agrega el flujo para que un juez pueda asignar puntaje a un participante (en este caso puede acceder a su `participantId`)

## Resumen de los cambios

- ([feat: 🗃️ assign problems to judges](https://github.com/Bea2000/ClimbUp/pull/24/commits/305429d4ac3e51c1fda824df306308dd7b0cadf6)) A nivel de base de datos se le asignan problemas/bloques a los jueces para que futuro solo les aparezcan aquellos que tienen asignados
- ([feat: 🔒 add encoder for ids](https://github.com/Bea2000/ClimbUp/pull/24/commits/d70e9cb00a28b9098c4c7eb763a76d04a522402a)) Se agrega un encoder que ayuda a la seguridad de la página ya que por ejemplo en vez de mostrar un *id* directo de nuestra base de datos muestra un valor cifrado (onda que _1_ cifrado es _ANKR21_)
- ([feat: ✨ add judge validator form](https://github.com/Bea2000/ClimbUp/pull/24/commits/9e1f8f543cf94dda2cf07f3190c11fe2141d9f33)) Los jueces se buscan ingresando su RUT donde les aparecerán todas las competencias futuras o actuales que están asignadas a ellos. Luego para ingresar a una deben ingresar la clave de la competencia
- ([feat: ✨ add scan participant for judge form](https://github.com/Bea2000/ClimbUp/pull/24/commits/848fba11b3a5e03917b56500cd24bb06259ee4b6)) Finalmente acceden a una página para poder escanear el QR del participante o también agregar el número (también encodeado) del participante

## Notas
Se asume que los jueces probablemente hagan todo el flujo (de buscar la competencia y acreditarse) antes de la competencia y que al minuto de la competencia tenga el scanner de participante abierto.

## Screenshots