### PR TITLE
[GBT-27] Reducir step en creación de competencia

### DIFF
--- a/src/app/dashboard/competitions/create/components/CreateCompetitionForm.tsx
+++ b/src/app/dashboard/competitions/create/components/CreateCompetitionForm.tsx
@@ -146,7 +146,7 @@ export default function CreateCompetitionForm() {
               label="Código"
               name={fields.code.name}
               type="text"
-              placeholder="Ej: Clave123"
+              placeholder="Ej: Escalada123"
               required
               errors={fields.code.errors}
               value={code}

--- a/src/app/dashboard/competitions/create/components/CreateCompetitionForm.tsx
+++ b/src/app/dashboard/competitions/create/components/CreateCompetitionForm.tsx
@@ -138,7 +138,7 @@ export default function CreateCompetitionForm() {
               placeholder="Ej: 90"
               required
               min="30"
-              step="30"
+              step="5"
               errors={fields.duration.errors}
             />
 


### PR DESCRIPTION
## Descripción 📝

El step de 30 minutos no permitía flexibilidad en las duraciones de competencia así que se cambió a steps de 5 minutos.
![image](https://github.com/user-attachments/assets/63618b63-7b95-4293-829a-274b75f54673)

Se aprovechó de ajustar el nombre del placeholder del código de competencia. Personalmente Clave123 cuando lo miraba me daba para pensar que podía poner 123 cuando en realidad el input es de al menos 6 caracteres.