### PR TITLE
[GBT-15] add gender to Participant

### DIFF
--- a/prisma/migrations/20250215171747_add_gender_to_participant/migration.sql
+++ b/prisma/migrations/20250215171747_add_gender_to_participant/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - Added the required column `gender` to the `Participant` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "Gender" AS ENUM ('MALE', 'FEMALE', 'OTHER');
+
+-- AlterTable
+ALTER TABLE "Participant" ADD COLUMN     "gender" "Gender" NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -81,6 +81,12 @@ model Judge {
   competition   Competition @relation(fields: [competitionId], references: [id])
 }
 
+enum Gender {
+  MALE
+  FEMALE
+  OTHER
+}
+
 model Participant {
   id                 Int                  @id @default(autoincrement())
   userId             Int                  @unique
@@ -90,6 +96,7 @@ model Participant {
   competition        Competition          @relation(fields: [competitionId], references: [id])
   problems           ParticipantProblem[]
   paymentReceiptPath String?
+  gender             Gender
 }
 
 model User {


### PR DESCRIPTION
## Descripción 📝
Se agrega el campo `gender` al modelo Participant para permitir registrar el género de los participantes en las competencias.

## Cambios realizados
- Se crea un nuevo enum `Gender` en el schema de Prisma con las opciones:
  - `MALE`
  - `FEMALE`
  - `OTHER`
- Se agrega el campo `gender` de tipo `Gender` al modelo Participant
- Se ejecuta la migración de base de datos correspondiente
