### PR TITLE
[GBT-22] add competition status

### DIFF
--- a/prisma/migrations/20250215192900_add_competition_status/migration.sql
+++ b/prisma/migrations/20250215192900_add_competition_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "CompetitionStatus" AS ENUM ('NOT_STARTED', 'IN_PROGRESS', 'FINISHED', 'CANCELLED');
+
+-- AlterTable
+ALTER TABLE "Competition" ADD COLUMN     "status" "CompetitionStatus" NOT NULL DEFAULT 'NOT_STARTED';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,13 @@ model Organizer {
   judges       Judge[]
 }
 
+enum CompetitionStatus {
+  NOT_STARTED
+  IN_PROGRESS
+  FINISHED
+  CANCELLED
+}
+
 model Competition {
   id           Int           @id @default(autoincrement())
   code         String
@@ -37,6 +44,7 @@ model Competition {
   judges       Judge[]
   basesPath    String?
   levelType    ClimbingGrade
+  status       CompetitionStatus @default(NOT_STARTED)
 }
 
 enum ClimbingGrade {


### PR DESCRIPTION
## Descripción 📝
Se agrega el campo `status` al modelo `Competition` para permitir el seguimiento del estado de las competencias a lo largo de su ciclo de vida.

## Cambios realizados
- Se crea un nuevo enum `CompetitionStatus` con las siguientes opciones:
  - `NOT_STARTED`: Estado inicial de la competencia
  - `IN_PROGRESS`: Competencia en curso
  - `FINISHED`: Competencia finalizada
  - `CANCELLED`: Competencia cancelada
- Se agrega el campo `status` de tipo `CompetitionStatus` al modelo `Competition`
- Se configura `NOT_STARTED` como el estado por defecto para nuevas competencias
