### PR TITLE
[GBT-20] feat: :sparkles: add manage Participants

### DIFF
--- a/prisma/migrations/20250216213205_add_participant_status/migration.sql
+++ b/prisma/migrations/20250216213205_add_participant_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ParticipantStatus" AS ENUM ('PENDING', 'CONFIRMED', 'REJECTED');
+
+-- AlterTable
+ALTER TABLE "Participant" ADD COLUMN     "status" "ParticipantStatus" NOT NULL DEFAULT 'PENDING';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -100,6 +100,13 @@ model Participant {
   competition        Competition          @relation(fields: [competitionId], references: [id])
   problems           ParticipantProblem[]
   paymentReceiptPath String?
+  status  ParticipantStatus @default(PENDING)
+}
+
+enum ParticipantStatus {
+  PENDING
+  CONFIRMED
+  REJECTED
 }
 
 model User {

--- a/src/app/actions/participants.ts
+++ b/src/app/actions/participants.ts
@@ -1,0 +1,28 @@
+'use server';
+
+import { SubmissionResult } from "@conform-to/react";
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { updateParticipantStatuses } from "@/lib/db/participant";
+
+export async function updateParticipants(_prevState: unknown, formData: FormData): Promise<SubmissionResult> {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return { status: 'error', error: { message: ['No se ha iniciado sesión'] } };
+  }
+
+  const participantsUpdated = JSON.parse(formData.get('participantsUpdated') as string);
+
+  if (!participantsUpdated) {
+    return { status: 'error', error: { message: ['No se ha realizado ningún cambio'] } };
+  }
+
+  try {
+    await updateParticipantStatuses(participantsUpdated);
+    return { status: 'success' };
+  } catch (error) {
+    return { status: 'error', error: { message: [`Error al actualizar participantes: ${error as string}`] } };
+  }
+} 

--- a/src/app/dashboard/competitions/[competitionId]/components/ParticipantsList.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/components/ParticipantsList.tsx
@@ -1,8 +1,12 @@
 'use client';
 
+import { ParticipantStatus } from "@prisma/client";
+
 import { ParticipantWithUser } from "@/types/participant";
 
-export function ParticipantsList({ participants }: { participants: ParticipantWithUser[] }) {
+export function ParticipantsList({ participants, competitionId }: { participants: ParticipantWithUser[], competitionId: number }) {
+  const confirmedParticipants = participants.filter(participant => participant.status === ParticipantStatus.CONFIRMED);
+
   return (
     <div>
       <h2 className="mb-4 text-xl font-bold">Participantes</h2>
@@ -16,7 +20,7 @@ export function ParticipantsList({ participants }: { participants: ParticipantWi
             </tr>
           </thead>
           <tbody>
-            {participants.map((participant) => (
+            {confirmedParticipants.map((participant) => (
               <tr key={participant.id}>
                 <td>{participant.user.name}</td>
                 <td>{participant.user.email}</td>

--- a/src/app/dashboard/competitions/[competitionId]/components/ParticipantsList.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/components/ParticipantsList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ParticipantStatus } from "@prisma/client";
+import Link from "next/link";
 
 import { ParticipantWithUser } from "@/types/participant";
 
@@ -9,7 +10,10 @@ export function ParticipantsList({ participants, competitionId }: { participants
 
   return (
     <div>
-      <h2 className="mb-4 text-xl font-bold">Participantes</h2>
+      <div className="flex justify-between">
+        <h2 className="mb-4 text-xl font-bold">Participantes</h2>
+        <Link href={`/dashboard/competitions/${competitionId}/participants`} className="btn btn-primary mb-4">Gestionar participantes</Link>
+      </div>
       <div className="overflow-x-auto">
         <table className="table table-zebra">
           <thead>

--- a/src/app/dashboard/competitions/[competitionId]/page.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/page.tsx
@@ -2,7 +2,9 @@
 
 import { notFound } from "next/navigation";
 
+import InfoAlert from "@/components/ui/InfoAlert";
 import { getCompetitionByIdWithOrganizerProblemsParticipantsAndJudges } from "@/lib/db/competition";
+import { getUnconfirmedParticipantsCountForOrganizer } from "@/lib/db/participant";
 
 import { CompetitionDetails } from "./components/CompetitionDetails";
 import { CompetitionStats } from "./components/CompetitionStats";
@@ -23,9 +25,18 @@ export default async function CompetitionPage(props: CompetitionPageProps) {
     notFound();
   }
 
+  const unconfirmedParticipants = await getUnconfirmedParticipantsCountForOrganizer(competition.organizerId);
+
   return (
     <div className="p-4">
       <div className="card bg-base-100 shadow-xl">
+        {unconfirmedParticipants > 0 && (
+          <InfoAlert
+            title="Participantes pendientes de confirmación"
+            description={`Tienes ${unconfirmedParticipants} ${unconfirmedParticipants === 1 ? "participante pendiente" : "participantes pendientes"} de confirmación`}
+            buttonText="Ver participantes"
+            link={`/dashboard/competitions/${competition.id}/participants`} />
+        )}
         <div className="card-body">
           <h1 className="card-title mb-6 text-3xl">{competition.name}</h1>
 
@@ -40,7 +51,7 @@ export default async function CompetitionPage(props: CompetitionPageProps) {
 
           <div className="divider"></div>
           
-          <ParticipantsList participants={competition.participants} />
+          <ParticipantsList participants={competition.participants} competitionId={competition.id} />
         </div>
       </div>
     </div>

--- a/src/app/dashboard/competitions/[competitionId]/participants/components/ParticipantsManage.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/participants/components/ParticipantsManage.tsx
@@ -1,0 +1,162 @@
+'use client';
+
+import { useForm } from '@conform-to/react';
+import { parseWithZod } from '@conform-to/zod';
+import { ParticipantStatus } from "@prisma/client";
+import React, { useActionState, useState } from "react";
+import { toast } from 'react-hot-toast';
+
+import { updateParticipants } from '@/app/actions/participants';
+import SubmitButton from '@/components/ui/SubmitButton';
+import { ParticipantWithUser } from "@/types/participant";
+
+import { UpdateParticipantsSchema } from '../schemas/UpdateParticipantsSchema';
+
+interface ParticipantsManageProps {
+  participants: ParticipantWithUser[];
+}
+
+export default function ParticipantsManage({ participants }: ParticipantsManageProps) {
+  const [selectedParticipants, setSelectedParticipants] = useState<ParticipantWithUser[]>(participants);
+  const originalParticipants = React.useRef(participants);
+  const [lastResult, formAction] = useActionState(updateParticipants, undefined);
+  const [changedParticipants, setChangedParticipants] = useState<{ id: number; status: ParticipantStatus }[]>([]);
+  const [form] = useForm({
+    lastResult,
+    onValidate({formData}) {
+      return parseWithZod(formData, {schema: UpdateParticipantsSchema});
+    },
+    shouldValidate: 'onBlur',
+    shouldRevalidate: 'onInput',
+  });
+
+  function toggleParticipantStatus(id: number | 'all', status: ParticipantStatus, currentStatus: ParticipantStatus) {
+    if (id === 'all') {
+      setSelectedParticipants(selectedParticipants.map(participant => (
+        participant.status === currentStatus
+          ? { ...participant, status }
+          : participant
+      )));
+    } else {
+      setSelectedParticipants(selectedParticipants.map(participant =>
+        ((participant.id === id && participant.status === currentStatus)
+          ? { ...participant, status }
+          : participant),
+      ));
+    }
+  }
+
+  React.useEffect(() => {
+    if (lastResult?.status === 'success') {
+      toast.success('Cambios confirmados');
+    } else if (lastResult?.status === 'error') {
+      toast.error(lastResult.error?.message?.[0] || 'Error al confirmar cambios');
+    }
+  }, [lastResult]);
+
+  React.useEffect(() => {
+    const newChangedParticipants = selectedParticipants.filter(participant => {
+      const original = originalParticipants.current.find(p => p.id === participant.id);
+      return original && original.status !== participant.status;
+    }).map(participant => ({
+      id: participant.id,
+      status: participant.status,
+    }));
+
+    setChangedParticipants(newChangedParticipants);
+  }, [selectedParticipants]);
+
+  const confirmedParticipants = selectedParticipants.filter(participant => participant.status === ParticipantStatus.CONFIRMED);
+  const pendingParticipants = selectedParticipants.filter(participant => participant.status === ParticipantStatus.PENDING);
+  const rejectedParticipants = selectedParticipants.filter(participant => participant.status === ParticipantStatus.REJECTED);
+
+  return (
+    <div className="w-full p-16">
+      <form id={form.id} onSubmit={form.onSubmit} action={formAction} className="w-full space-y-4 px-4">
+        <div className="flex items-end justify-between">
+          <h1 className="text-2xl font-bold leading-10">Gestionar participantes</h1>
+          <SubmitButton label="Confirmar cambios" loadingLabel="Confirmando..." disabled={changedParticipants.length === 0}/>
+        </div>
+        
+        <h2 className="mb-2 text-xl">Participantes pendientes</h2>
+        <div className="mb-4">
+          <button className="btn btn-primary mr-2" disabled={pendingParticipants.length === 0} onClick={() => toggleParticipantStatus('all', ParticipantStatus.CONFIRMED, ParticipantStatus.PENDING)}>Confirmar todos</button>
+          <button className="btn btn-secondary" disabled={pendingParticipants.length === 0} onClick={() => toggleParticipantStatus('all', ParticipantStatus.REJECTED, ParticipantStatus.PENDING)}>Rechazar todos</button>
+        </div>
+        <table className="table mb-8 w-full">
+          <thead>
+            <tr>
+              <th className="w-1/4">Nombre</th>
+              <th className="w-1/4">Email</th>
+              <th className="w-1/4">RUT</th>
+              <th className="w-1/3">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {pendingParticipants.map(participant => (
+              <tr key={participant.id}>
+                <td>{participant.user.name}</td>
+                <td>{participant.user.email}</td>
+                <td>{participant.user.rut}</td>
+                <td>
+                  <button className="btn btn-info btn-sm mr-2">Ver datos de inscripción</button>
+                  <button className="btn btn-success btn-sm mr-2" onClick={() => toggleParticipantStatus(participant.id, ParticipantStatus.CONFIRMED, ParticipantStatus.PENDING)}>Confirmar</button>
+                  <button className="btn btn-error btn-sm" onClick={() => toggleParticipantStatus(participant.id, ParticipantStatus.REJECTED, ParticipantStatus.PENDING)}>Rechazar</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <h2 className="mb-2 text-xl">Participantes confirmados</h2>
+        <table className="table mb-8 w-full">
+          <thead>
+            <tr>
+              <th className="w-1/4">Nombre</th>
+              <th className="w-1/4">Email</th>
+              <th className="w-1/4">RUT</th>
+              <th className="w-1/3">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {confirmedParticipants.map(participant => (
+              <tr key={participant.id}>
+                <td>{participant.user.name}</td>
+                <td>{participant.user.email}</td>
+                <td>{participant.user.rut}</td>
+                <td>
+                  <button className="btn btn-info btn-sm mr-2">Ver datos de inscripción</button>
+                  <button className="btn btn-error btn-sm" onClick={() => toggleParticipantStatus(participant.id, ParticipantStatus.REJECTED, ParticipantStatus.CONFIRMED)}>Rechazar</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <h2 className="mb-2 text-xl">Participantes rechazados</h2>
+        <table className="table mb-8 w-full">
+          <thead>
+            <tr>
+              <th className="w-1/4">Nombre</th>
+              <th className="w-1/4">Email</th>
+              <th className="w-1/4">RUT</th>
+              <th className="w-1/3">Acciones</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rejectedParticipants.map(participant => (
+              <tr key={participant.id}>
+                <td>{participant.user.name}</td>
+                <td>{participant.user.email}</td>
+                <td>{participant.user.rut}</td>
+                <td>
+                  <button className="btn btn-info btn-sm mr-2">Ver datos de inscripción</button>
+                  <button className="btn btn-success btn-sm" onClick={() => toggleParticipantStatus(participant.id, ParticipantStatus.CONFIRMED, ParticipantStatus.REJECTED)}>Aceptar</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <input type="hidden" name="participantsUpdated" value={JSON.stringify(changedParticipants)} />
+      </form>
+    </div>
+  );
+}

--- a/src/app/dashboard/competitions/[competitionId]/participants/page.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/participants/page.tsx
@@ -1,0 +1,20 @@
+import { getParticipantsWithUserByCompetitionId } from "@/lib/db/participant";
+
+import ParticipantsManage from "./components/ParticipantsManage";
+
+interface ParticipantsManagePageProps {
+  params: Promise<{
+    competitionId: string;
+  }>;
+}
+
+export default async function ParticipantsManagePage(props: ParticipantsManagePageProps) {
+  const params = await props.params;
+  const participants = await getParticipantsWithUserByCompetitionId(parseInt(params.competitionId));
+
+  return (
+    <div className="w-full">
+      <ParticipantsManage participants={participants} />
+    </div>
+  )
+}

--- a/src/app/dashboard/competitions/[competitionId]/participants/schemas/UpdateParticipantsSchema.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/participants/schemas/UpdateParticipantsSchema.tsx
@@ -1,0 +1,21 @@
+import { ParticipantStatus } from "@prisma/client";
+import { z } from "zod";
+
+export const UpdateParticipantsSchema = z.object({
+  participantsUpdated: z.string(),
+}).refine((data) => {
+  try {
+    const participantsUpdated = JSON.parse(data.participantsUpdated);
+    return Array.isArray(participantsUpdated) && participantsUpdated.every(participant =>
+      typeof participant.id === 'number' &&
+      Object.values(ParticipantStatus).includes(participant.status),
+    );
+  } catch {
+    return false;
+  }
+}, {
+  path: ['participantsUpdated'],
+  message: "Formato de datos inválido",
+});
+
+export type UpdateParticipantsFormData = z.infer<typeof UpdateParticipantsSchema>;

--- a/src/app/dashboard/competitions/manage/[competitionId]/judges/add/components/AddJudgeForm.tsx
+++ b/src/app/dashboard/competitions/manage/[competitionId]/judges/add/components/AddJudgeForm.tsx
@@ -64,7 +64,7 @@ export default function AddJudgeForm({ competitionId }: AddJudgeFormProps) {
               />
 
               <RutInput
-                error={fields.rut?.errors?.[0]}
+                errors={fields.rut?.errors}
               />
             </div>
 

--- a/src/components/RutInput.tsx
+++ b/src/components/RutInput.tsx
@@ -32,6 +32,7 @@ export function RutInput({ errors }: RutInputProps) {
       placeholder="RUT (ej: 12.345.678-9)"
       errors={errors}
       onChange={handleRutChange}
+      maxLength={12}
     />
   );
 } 

--- a/src/components/ui/FormInput.tsx
+++ b/src/components/ui/FormInput.tsx
@@ -14,6 +14,7 @@ interface FormInputProps {
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   onRightIconClick?: () => void;
+  maxLength?: number;
 }
 
 export default function FormInput({ 
@@ -28,6 +29,7 @@ export default function FormInput({
   className = "w-full",
   extraElement,
   value,
+  maxLength,
   onChange,
   leftIcon,
   rightIcon,
@@ -64,6 +66,7 @@ export default function FormInput({
           step={step}
           value={value}
           onChange={onChange}
+          maxLength={maxLength}
         />
         {rightIcon && (
           <button 

--- a/src/components/ui/InfoAlert.tsx
+++ b/src/components/ui/InfoAlert.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { Info } from "@phosphor-icons/react";
+import Link from "next/link";
+
+interface InfoAlertProps {
+  title: string;
+  description: string;
+  buttonText: string;
+  link: string;
+}
+export default function InfoAlert({ title, description, buttonText, link }: InfoAlertProps) {
+  return (
+    <div role="alert" className="alert rounded-lg bg-gray-800 p-4 text-white shadow-lg">
+      <Info size={32} />
+      <div>
+        <h3 className="font-bold">{title}</h3>
+        <div className="text-xs">{description}</div>
+      </div>
+      <Link className="btn btn-sm bg-gray-700 px-8" href={link}>{buttonText}</Link>
+    </div>
+  )
+}

--- a/src/components/ui/SubmitButton.tsx
+++ b/src/components/ui/SubmitButton.tsx
@@ -1,11 +1,11 @@
 import { useFormStatus } from 'react-dom';
 
-export default function SubmitButton({ label, loadingLabel }: { label: string, loadingLabel: string }) {
+export default function SubmitButton({ label, loadingLabel, disabled }: { label: string, loadingLabel: string, disabled?: boolean }) {
   const { pending } = useFormStatus();
 
   return (
     <div className="form-control mt-6">
-      <button type="submit" className="btn btn-primary w-full" disabled={pending}>
+      <button type="submit" className="btn btn-primary w-full" disabled={pending || disabled}>
         {pending ? loadingLabel : label}
       </button>
     </div>

--- a/src/lib/db/participant.ts
+++ b/src/lib/db/participant.ts
@@ -21,3 +21,14 @@ export async function getLastCompetitionParticipantsCountForOrganizer(organizerI
     },
   });
 }
+
+export async function getUnconfirmedParticipantsCountForOrganizer(organizerId: number) {
+  return await prisma.participant.count({
+    where: {
+      competition: {
+        organizerId,
+      },
+      participantStatus: "PENDING",
+    },
+  });
+}

--- a/src/lib/db/participant.ts
+++ b/src/lib/db/participant.ts
@@ -1,3 +1,5 @@
+import { ParticipantStatus } from "@prisma/client";
+
 import { getLastCompetitionForOrganizer } from "./competition";
 import prisma from "./prisma";
 
@@ -28,7 +30,26 @@ export async function getUnconfirmedParticipantsCountForOrganizer(organizerId: n
       competition: {
         organizerId,
       },
-      participantStatus: "PENDING",
+      status: "PENDING",
     },
   });
+}
+
+export async function getParticipantsWithUserByCompetitionId(competitionId: number) {
+  return await prisma.participant.findMany({
+    where: {
+      competitionId,
+    },
+    include: {
+      user: true,
+    },
+  });
+}
+
+export async function updateParticipantStatuses(updates: { id: number, status: ParticipantStatus }[]) {
+  const updatePromises = updates.map(update => prisma.participant.update({
+    where: { id: update.id },
+    data: { status: update.status },
+  }));
+  await Promise.all(updatePromises);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3851,7 +3851,7 @@ regenerator-runtime@^0.14.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
   integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
-regexp.prototype.flags@^1.5.2, regexp.prototype.flags@^1.5.3:
+regexp.prototype.flags@^1.5.3:
   version "1.5.3"
   resolved "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.3.tgz"
   integrity sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==


### PR DESCRIPTION
## Descripción 📝

Me equivoque y sin querer subir dos cosas en esta rama pero hay un mini arreglo donde
Ahora si el RUT se recorta a los 12 caracteres 

Tambien se agrega la vista de gestionar participantes para confirmar y rechazar participantes que se inscriben a una competencia
