### PR TITLE
[GBT-72] Implementación de Toggle de Tema Claro/Oscuro

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,2 +1,4 @@
 @import "tailwindcss";
-@plugin "daisyui";
+@plugin "daisyui" {
+    themes: cupcake --default, dark --prefersdark;
+}

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -7,6 +7,8 @@ import { useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { useState } from "react";
 
+import ThemeToggle from "./ThemeToggle";
+
 interface NavbarProps {
   organizerName: string;
   superAdmin: boolean;
@@ -49,6 +51,7 @@ export default function Navbar({ organizerName, superAdmin }: NavbarProps) {
         </button>
       </div>
       <div className="flex-none gap-2">
+        <ThemeToggle />
         <button onClick={() => signOut({ callbackUrl: '/' })} className="btn btn-ghost">
           <SignOut size={24} color="#a3aab8" />
           Cerrar Sesión

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { Sun, Moon } from "@phosphor-icons/react";
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [isDarkMode, setIsDarkMode] = useState(false);
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem('theme') || 'dark';
+    setIsDarkMode(savedTheme === 'dark');
+    document.documentElement.setAttribute('data-theme', savedTheme);
+  }, []);
+
+  function toggleTheme() {
+    const newTheme = isDarkMode ? 'cupcake' : 'dark';
+    setIsDarkMode(!isDarkMode);
+    localStorage.setItem('theme', newTheme);
+    document.documentElement.setAttribute('data-theme', newTheme);
+  }
+
+  return (
+    <label className="swap swap-rotate">
+      <input 
+        type="checkbox" 
+        className="theme-controller" 
+        checked={isDarkMode}
+        onChange={toggleTheme}
+      />
+      <Sun size={24} className="swap-off size-6 fill-current" />
+      <Moon size={24} className="swap-on size-6 fill-current" />
+    </label>
+  );
+}


### PR DESCRIPTION
## Descripción 📝
Se implementa toggle para cambiar entre tema claro y oscuro.

## Resumen de los cambios 🛠
- Configuración: Implementación de temas "retro" (claro) y "dark" (oscuro) en DaisyUI.
- Nuevo Componente: Creación de `ThemeToggle.tsx` con iconos de sol/luna y persistencia en localStorage.
- Integración: Incorporación del toggle en la barra de navegación.
- UX: Cambio de tema con un solo clic y feedback visual inmediato.

## Screenshots 📸
- Tema **oscuro** (_dark_) 🌚 
<img width="3000" height="1644" alt="image" src="https://github.com/user-attachments/assets/7299e5e6-6084-48af-a11b-b345c14b535e" />

- Tema **claro** (_cupcake_) ☀️
<img width="3021" height="1643" alt="image" src="https://github.com/user-attachments/assets/4e9ab5c5-7c82-4772-a1e0-b3ecdb5d9993" />