### PR TITLE
[GBT-73] Se agrega toggle para habilitar/inhabilitar inscripción a competencias

### DIFF
--- a/prisma/migrations/20250419004008_add_accepts_registrations_to_competition/migration.sql
+++ b/prisma/migrations/20250419004008_add_accepts_registrations_to_competition/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Competition" ADD COLUMN     "acceptsRegistrations" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema/competition.prisma
+++ b/prisma/schema/competition.prisma
@@ -16,6 +16,7 @@ model Competition {
   registerFormSettings  Json?
   categories            Json?
   status                CompetitionStatus        @default(NOT_STARTED)
+  acceptsRegistrations  Boolean                  @default(true)
 }
 
 model Problem {

--- a/src/app/actions/competition.ts
+++ b/src/app/actions/competition.ts
@@ -6,7 +6,7 @@ import { getServerSession } from "next-auth";
 
 import { authOptions } from "@/lib/auth";
 import { REVERSE_GRADE_TYPES } from "@/lib/constant/problem.conf";
-import { addRegisterFormSettingsToCompetitionById, createNewCompetition, getCompetitionById } from "@/lib/db/competition";
+import { addRegisterFormSettingsToCompetitionById, createNewCompetition, getCompetitionById, updateCompetitionAcceptsRegistrations } from "@/lib/db/competition";
 import { createNewParticipant, addParticipantToCompetition, getParticipantCompetitionByRutAndCompetitionId } from "@/lib/db/participant";
 import { uploadBases, uploadPaymentFile } from "@/lib/s3";
 import { unformatCurrency } from "@/lib/utils";
@@ -117,6 +117,21 @@ export async function createCompetitionRegisterForm(_prevState: unknown, formDat
     return { status: 'success' };
   } catch {
     return { status: 'error', error: { message: ['Error al crear el formulario de registro'] } };
+  }
+}
+
+export async function updateCompetitionRegistrationStatus(competitionId: number, acceptsRegistrations: boolean) {
+  const session = await getServerSession(authOptions);
+
+  if (!session) {
+    return { status: 'error', error: { message: ['No se ha iniciado sesión'] } };
+  }
+  
+  try {
+    await updateCompetitionAcceptsRegistrations(competitionId, acceptsRegistrations);
+    return { status: 'success' };
+  } catch {
+    return { status: 'error', error: { message: ['Error al actualizar el estado de inscripciones de la competencia'] } };
   }
 }
 

--- a/src/app/dashboard/competitions/[competitionId]/components/RegistrationToggle.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/components/RegistrationToggle.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+
+import { updateCompetitionRegistrationStatus } from '@/app/actions/competition';
+
+interface RegistrationToggleProps {
+  competitionId: number;
+  initialAcceptsRegistrations: boolean;
+  isDisabled: boolean;
+}
+
+export function RegistrationToggle({ 
+  competitionId, 
+  initialAcceptsRegistrations, 
+  isDisabled, 
+}: RegistrationToggleProps) {
+  const [acceptsRegistrations, setAcceptsRegistrations] = useState(initialAcceptsRegistrations);
+
+  useEffect(() => {
+    async function updateRegistrationStatus() {
+      if (isDisabled && initialAcceptsRegistrations) {
+        try {
+          const result = await updateCompetitionRegistrationStatus(competitionId, false);
+          if (result.status === 'success') {
+            setAcceptsRegistrations(false);
+          }
+        } catch {
+          // Ignoramos silenciosamente cualquier error
+        }
+      }
+    }
+
+    updateRegistrationStatus();
+  }, [isDisabled, initialAcceptsRegistrations, competitionId]);
+
+  async function handleToggle() {
+    const originalValue = acceptsRegistrations;
+    const newValue = !originalValue;
+    
+    try {
+      setAcceptsRegistrations(newValue);
+      
+      const result = await updateCompetitionRegistrationStatus(competitionId, newValue);
+      
+      if (result.status === 'error') {
+        setAcceptsRegistrations(originalValue);
+      }
+    } catch {
+      setAcceptsRegistrations(originalValue);
+    }
+  }
+
+  return (
+    <div className="form-control">
+      <label className="label cursor-pointer justify-start gap-4">
+        <span className="label-text font-medium">
+          {acceptsRegistrations ? 'Inscripciones abiertas' : 'Inscripciones cerradas'}
+        </span>
+        {isDisabled ? (
+          <div className="tooltip tooltip-right" data-tip="No se puede modificar porque la fecha de la competencia ya pasó">
+            <input 
+              type="checkbox" 
+              className="toggle toggle-primary" 
+              checked={acceptsRegistrations}
+              onChange={handleToggle}
+              disabled={true}
+            />
+          </div>
+        ) : (
+          <input 
+            type="checkbox" 
+            className="toggle toggle-primary" 
+            checked={acceptsRegistrations}
+            onChange={handleToggle}
+          />
+        )}
+      </label>
+    </div>
+  );
+}

--- a/src/app/dashboard/competitions/[competitionId]/page.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/page.tsx
@@ -6,11 +6,13 @@ import { notFound } from "next/navigation";
 import InfoAlert from "@/components/ui/InfoAlert";
 import { getCompetitionByIdWithOrganizerProblemsJudgesAndParticipants } from "@/lib/db/competition";
 import { getParticipantsInformationByCompetitionId, getUnconfirmedParticipantsCountForCompetitionByCompetitionId } from "@/lib/db/participant";
+import { isCompetitionDatePassed } from "@/lib/utils";
 
 import { CompetitionDetails } from "./components/CompetitionDetails";
 import { CompetitionStats } from "./components/CompetitionStats";
 import { ConfirmedParticipantsList } from "./components/ParticipantsList";
 import { ProblemsList } from "./components/ProblemsList";
+import { RegistrationToggle } from "./components/RegistrationToggle";
 
 interface CompetitionPageProps {
   params: Promise<{
@@ -38,6 +40,8 @@ export default async function CompetitionPage(props: CompetitionPageProps) {
   }
   
   const unconfirmedParticipants = await getUnconfirmedParticipantsCountForCompetitionByCompetitionId(competition.id);
+  
+  const competitionDatePassed = isCompetitionDatePassed(competition.date);
 
   return (
     <div className="p-4">
@@ -56,6 +60,14 @@ export default async function CompetitionPage(props: CompetitionPageProps) {
               <Link href={getRedirectToRegisterForm()} className="btn btn-primary">{competition.registerFormSettings ? 'Editar formulario de registro' : 'Crear formulario de registro'}</Link>
               <Link href={`/dashboard/competitions/${competition.id}/edit`} className="btn btn-primary">Editar</Link>
             </div>
+          </div>
+          
+          <div className="mb-4">
+            <RegistrationToggle 
+              competitionId={competition.id} 
+              initialAcceptsRegistrations={competition.acceptsRegistrations}
+              isDisabled={competitionDatePassed}
+            />
           </div>
 
           <div className="grid grid-cols-1 gap-6 md:grid-cols-2">

--- a/src/lib/db/competition.ts
+++ b/src/lib/db/competition.ts
@@ -156,3 +156,14 @@ export async function getParticipantsCountForCompetitionByCompetitionId(competit
   const participants = await getParticipantsByCompetitionId(competitionId);
   return participants.length;
 }
+
+export async function updateCompetitionAcceptsRegistrations(competitionId: number, acceptsRegistrations: boolean) {
+  return await prisma.competition.update({
+    where: {
+      id: competitionId,
+    },
+    data: {
+      acceptsRegistrations,
+    },
+  });
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -21,3 +21,15 @@ export function unformatCurrency(value: string) {
 export function formatPrice(price: string) {
   return parseInt(price.replace(/\./g, ''), 10);
 }
+
+/**
+ * Verifica si la fecha de una competencia ya ha pasado
+ * @param competitionDate - Fecha de la competencia (almacenada en UTC en la base de datos)
+ * @returns true si la fecha de la competencia ya pasó, false en caso contrario
+ */
+export function isCompetitionDatePassed(competitionDate: Date | string): boolean {
+  const currentDate = new Date();
+  const dateToCompare = new Date(competitionDate);
+  
+  return currentDate > dateToCompare;
+}


### PR DESCRIPTION
## Descripción 📝
Se agrega atributo `acceptsRegistrations` en el _schema_ de `Competition` para saber si la competencia está aceptando registros a su competencia o no. 

Se agrega para controlar este valor un toggle en la vista de competencia para habilitar/desabilitar la inscripción a la competencia.

Además, si la competencia ya pasó su fecha, automáticamente se modifica este valor a false (no acepta inscripciones)

## Comentarios 💬
En el futuro habrá que mejorar el formulario de registro para que permita gestionar distintas categorías (novicio masculino, avanzado masculino, experto masculino, ...) y a su vez que permita restringir la inscripción a cierta categoría porque ya se alcanzaron los cupos permitidos.

## Screenshots 📸
[![image](https://github.com/user-attachments/assets/4f3d74e7-fe23-4f9a-82a6-41ddf00e0c57)
](https://github.com/user-attachments/assets/31456601-cf04-426e-bd3d-52f539e6ac2f)