### PR TITLE
[GBT-76] Agregar categorías en form de creación de competencia

### DIFF
--- a/prisma/migrations/20250422024849_add_categories_field/migration.sql
+++ b/prisma/migrations/20250422024849_add_categories_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Competition" ADD COLUMN     "categories" JSONB;

--- a/prisma/schema/competition.prisma
+++ b/prisma/schema/competition.prisma
@@ -14,6 +14,7 @@ model Competition {
   basesPath             String?
   levelType             ClimbingGrade
   registerFormSettings  Json?
+  categories            Json?
   status                CompetitionStatus        @default(NOT_STARTED)
 }
 

--- a/src/app/actions/competition.ts
+++ b/src/app/actions/competition.ts
@@ -29,6 +29,8 @@ export async function createCompetition(_prevState: unknown, formData: FormData)
   const code = formData.get('code') as string;
   const organizerId = session?.user.organizerId;
   const levelType = formData.get('levelType') as string;
+  const categoriesData = formData.get('categories');
+  const categories = categoriesData ? JSON.parse(categoriesData as string) as string[] : [];
 
   const levelTypeEnum = REVERSE_GRADE_TYPES[levelType as keyof typeof REVERSE_GRADE_TYPES] as ClimbingGrade;
 
@@ -40,6 +42,7 @@ export async function createCompetition(_prevState: unknown, formData: FormData)
     code, 
     organizerId, 
     levelType: levelTypeEnum,
+    categories,
   };
   
   try {

--- a/src/app/dashboard/competitions/[competitionId]/components/CompetitionDetails.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/components/CompetitionDetails.tsx
@@ -21,6 +21,18 @@ export function CompetitionDetails( { competition }: CompetitionDetailsProps ) {
           <p><span className="font-bold">Duración:</span> {competition.duration} minutos</p>
           <p><span className="font-bold">Organizador:</span> {competition.organizer.name}</p>
           <p><span className="font-bold">Estado:</span> <StatusBadge status={competition.status} /></p>
+          <div className="flex flex-col gap-2">
+            <span className="font-bold">Categorías:</span>
+            <div className="flex flex-wrap gap-2">
+              {Array.isArray(competition.categories) && competition.categories.length > 0 ? (
+                competition.categories.map((category, index) => (
+                  <span key={index} className="badge badge-primary">{String(category)}</span>
+                ))
+              ) : (
+                <span className="text-sm text-gray-500">No hay categorías definidas</span>
+              )}
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/dashboard/competitions/create/components/CreateCompetitionForm.tsx
+++ b/src/app/dashboard/competitions/create/components/CreateCompetitionForm.tsx
@@ -2,9 +2,10 @@
 
 import { useForm } from '@conform-to/react';
 import { parseWithZod } from '@conform-to/zod';
+import { Trash } from "@phosphor-icons/react";
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import React, { useActionState } from 'react';
+import React, { useActionState, useState } from 'react';
 import { toast } from 'react-hot-toast';
 
 import { createCompetition } from '@/app/actions/competition';
@@ -22,6 +23,8 @@ import { CreateCompetitionSchema } from '../schemas/createCompetitionSchema';
 export default function CreateCompetitionForm() {
   const router = useRouter();
   const [code, setCode] = React.useState('');
+  const [categories, setCategories] = useState<string[]>([]);
+  const [currentCategory, setCurrentCategory] = useState<string>('');
   const [lastResult, formAction] = useActionState(createCompetition, undefined);
   const [form, fields] = useForm({
     lastResult,
@@ -76,6 +79,24 @@ export default function CreateCompetitionForm() {
     setLocationInput(address);
     fields.location.value = address;
     setShowSuggestions(false);
+  }
+
+  function handleAddCategory() {
+    if (currentCategory) {
+      setCategories([...categories, currentCategory]);
+      setCurrentCategory('');
+    }
+  }
+
+  function handleCategoryKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'Enter' && currentCategory) {
+      e.preventDefault();
+      handleAddCategory();
+    }
+  }
+
+  function handleDeleteCategory(index: number) {
+    setCategories(categories.filter((_, i) => i !== index));
   }
 
   return (
@@ -153,6 +174,52 @@ export default function CreateCompetitionForm() {
               onChange={(e) => setCode(e.target.value)}
               extraElement={generateCodeButton}
             />
+
+            <input
+              type="hidden"
+              name="categories"
+              value={JSON.stringify(categories)}
+            />
+
+            <div className="space-y-2">
+              <p className="text-lg font-medium text-gray-700">Categorías</p>
+              
+              {categories.length > 0 && categories.map((category, index) => (
+                <div key={`category-${index}`} className="flex flex-row items-center gap-2">
+                  <p className="flex-none">- {category}</p>
+                  <button
+                    type="button"
+                    className="btn btn-ghost btn-sm text-error"
+                    onClick={() => handleDeleteCategory(index)}
+                  >
+                    <Trash className="size-5" />
+                  </button>
+                </div>
+              ))}
+              
+              <div className="flex flex-row items-end gap-4">
+                <div className="flex-1">
+                  <FormInput
+                    label="Nombre de Categoría"
+                    name="currentCategory"
+                    type="text"
+                    placeholder="Ej: Avanzados Masculino"
+                    value={currentCategory}
+                    onChange={(e) => setCurrentCategory(e.target.value)}
+                    onKeyDown={handleCategoryKeyDown}
+                  />
+                </div>
+                
+                <button 
+                  className="btn btn-primary" 
+                  type="button"
+                  onClick={handleAddCategory}
+                  disabled={!currentCategory}
+                >
+                  Agregar categoría
+                </button>
+              </div>
+            </div>
 
             <SubmitButton
               label="Crear Competencia"

--- a/src/app/dashboard/competitions/create/schemas/createCompetitionSchema.tsx
+++ b/src/app/dashboard/competitions/create/schemas/createCompetitionSchema.tsx
@@ -13,6 +13,7 @@ export const CreateCompetitionSchema = z.object({
     }),
   duration: z.number({ message: "Duración requerida" }).min(1, { message: "Duración debe ser mayor a 0" }),
   levelType: z.string({ message: "Tipo de graduación requerido" }),
+  categories: z.string().optional(),
 });
 
 export type CreateCompetitionFormData = z.infer<typeof CreateCompetitionSchema>;

--- a/src/components/ui/FormInput.tsx
+++ b/src/components/ui/FormInput.tsx
@@ -11,6 +11,7 @@ interface FormInputProps {
   extraElement?: React.ReactNode;
   value?: string;
   onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown?: (e: React.KeyboardEvent<HTMLInputElement>) => void;
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   onRightIconClick?: () => void;
@@ -31,6 +32,7 @@ export default function FormInput({
   value,
   maxLength,
   onChange,
+  onKeyDown,
   leftIcon,
   rightIcon,
   onRightIconClick,
@@ -66,6 +68,7 @@ export default function FormInput({
           step={step}
           value={value}
           onChange={onChange}
+          onKeyDown={onKeyDown}
           maxLength={maxLength}
         />
         {rightIcon && (

--- a/src/lib/db/competition.ts
+++ b/src/lib/db/competition.ts
@@ -6,7 +6,7 @@ import { getParticipantsByCompetitionId } from "./participant";
 import prisma from "./prisma";
 
 export async function createNewCompetition(competition: CompetitionData) {
-  const { name, location, date, duration, code, organizerId, levelType } = competition;
+  const { name, location, date, duration, code, organizerId, levelType, categories } = competition;
   const newCompetition = await prisma.competition.create({
     data: {
       name,
@@ -15,6 +15,7 @@ export async function createNewCompetition(competition: CompetitionData) {
       duration,
       code,
       levelType,
+      ...(categories && categories.length > 0 ? { categories } : {}),
       organizer: {
         connect: {
           id: organizerId,
@@ -22,6 +23,7 @@ export async function createNewCompetition(competition: CompetitionData) {
       },
     },
   });
+  
   return newCompetition;
 }
 

--- a/src/types/competition.d.ts
+++ b/src/types/competition.d.ts
@@ -8,6 +8,7 @@ export type CompetitionData = {
     code: string;
     organizerId: number;
     levelType: ClimbingGrade;
+    categories?: string[];
 }
 
 export type CompetitionWithOrganizer = Competition & { organizer: Organizer }; 


### PR DESCRIPTION
## Descripción 📝

Implementación de categorías para competencias de escalada en ClimbUp. Esta funcionalidad permite a los organizadores definir diferentes categorías (como "Avanzados Masculino", "Novicio Femenino", etc.) al momento de crear una competencia, facilitando la organización de los participantes.

## Resumen de los cambios 🛠

### Cambios en la base de datos
- Agregado el campo `categories` de tipo `Json?` al modelo Competition en el esquema de Prisma
- Generada la migración correspondiente para actualizar la estructura de la base de datos

### Cambios en la interfaz de usuario
- Implementada la funcionalidad para agregar y eliminar categorías en el formulario de creación de competencias
- Añadida visualización de categorías como badges en la página de detalles de la competencia

### Cambios en el backend
- Actualizada la función `createNewCompetition` para guardar las categorías directamente en el modelo Competition
- Modificados los tipos TypeScript para reflejar la nueva estructura de datos
- Optimizado el manejo de categorías para garantizar compatibilidad con el cliente de Prisma

### Mejoras de UX
- Las categorías se muestran como _badges_ coloridos para mejor visualización
- Implementado manejo adecuado para casos donde no hay categorías definidas
- Mejorada la organización visual de la información en la página de detalles

## Screenshots 📸
![Screenshot 2025-04-21 at 11 18 24 PM](https://github.com/user-attachments/assets/88ab891f-9077-4936-b898-3bef50beef5c)

https://github.com/user-attachments/assets/787e6568-0b7b-43fe-b8d5-9d0c0a6688ec


