### PR TITLE
[GBT-50] Feat/add register form

### DIFF
--- a/prisma/migrations/20250427180521_add_rut_to_participant/migration.sql
+++ b/prisma/migrations/20250427180521_add_rut_to_participant/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[rut]` on the table `Participant` will be added. If there are existing duplicate values, this will fail.
+  - Added the required column `rut` to the `Participant` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Participant" ADD COLUMN     "rut" TEXT NOT NULL;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Participant_rut_key" ON "Participant"("rut");

--- a/prisma/schema/competition.prisma
+++ b/prisma/schema/competition.prisma
@@ -1,20 +1,20 @@
 model Competition {
-  id                   Int               @id @default(autoincrement())
-  code                 String
-  name                 String
-  location             String
-  date                 DateTime
-  organizerId          Int
-  organizer            Organizer         @relation(fields: [organizerId], references: [id])
-  duration             Int // in minutes
-  startTime            DateTime?
-  problems             Problem[]         @relation("CompetitionProblems")
-  participants         ParticipantCompetition[] @relation("ParticipantCompetitions")
-  judges               Judge[]           @relation("JudgeCompetitions")
-  basesPath            String?
-  levelType            ClimbingGrade
-  registerFormSettings Json?
-  status               CompetitionStatus @default(NOT_STARTED)
+  id                    Int                      @id @default(autoincrement())
+  code                  String
+  name                  String
+  location              String
+  date                  DateTime
+  organizerId           Int
+  organizer             Organizer                @relation(fields: [organizerId], references: [id])
+  duration              Int // in minutes
+  startTime             DateTime?
+  problems              Problem[]                @relation("CompetitionProblems")
+  participants          ParticipantCompetition[] @relation("ParticipantCompetitions")
+  judges                Judge[]                  @relation("JudgeCompetitions")
+  basesPath             String?
+  levelType             ClimbingGrade
+  registerFormSettings  Json?
+  status                CompetitionStatus        @default(NOT_STARTED)
 }
 
 model Problem {
@@ -26,15 +26,15 @@ model Problem {
   discountPerAttempt Int
   competitionId      Int
   competition        Competition          @relation("CompetitionProblems", fields: [competitionId], references: [id])
-  participants       ParticipantProblem[] 
+  participants       ParticipantProblem[]
   judges             Judge[]              @relation("JudgeProblems")
 }
 
 model Judge {
-  id            Int           @id @default(autoincrement())
-  email         String        @unique
-  competitions  Competition[] @relation("JudgeCompetitions")
-  problems      Problem[]     @relation("JudgeProblems")
-  organizerId   Int
-  organizer     Organizer    @relation("OrganizerJudges", fields: [organizerId], references: [id])
+  id           Int           @id @default(autoincrement())
+  email        String        @unique
+  competitions Competition[] @relation("JudgeCompetitions")
+  problems     Problem[]     @relation("JudgeProblems")
+  organizerId  Int
+  organizer    Organizer     @relation("OrganizerJudges", fields: [organizerId], references: [id])
 }

--- a/prisma/schema/participant.prisma
+++ b/prisma/schema/participant.prisma
@@ -1,31 +1,32 @@
 model ParticipantCompetition {
-  id              Int         @id @default(autoincrement())
+  id              Int                  @id @default(autoincrement())
   participantId   Int
-  participant     Participant @relation(fields: [participantId], references: [id])
+  participant     Participant          @relation(fields: [participantId], references: [id])
   competitionId   Int
-  competition     Competition @relation("ParticipantCompetitions", fields: [competitionId], references: [id])
+  competition     Competition          @relation("ParticipantCompetitions", fields: [competitionId], references: [id])
   finalScore      Int?
   category        String?
   userInformation Json?
-  status          ParticipantStatus @default(PENDING)
+  status          ParticipantStatus    @default(PENDING)
   problems        ParticipantProblem[] @relation("ParticipantCompetitionsInformation")
 }
 
 model ParticipantProblem {
-  id                    Int                   @id @default(autoincrement())
-  problemId            Int
-  problem              Problem               @relation(fields: [problemId], references: [id])
-  participantId        Int
-  participant          Participant           @relation(fields: [participantId], references: [id])
+  id                       Int                    @id @default(autoincrement())
+  problemId                Int
+  problem                  Problem                @relation(fields: [problemId], references: [id])
+  participantId            Int
+  participant              Participant            @relation(fields: [participantId], references: [id])
   participantCompetitionId Int
-  participantCompetition ParticipantCompetition @relation("ParticipantCompetitionsInformation", fields: [participantCompetitionId], references: [id])
-  attempts             Int                   @default(0)
-  completed            Boolean               @default(false)
-  points               Int?
+  participantCompetition   ParticipantCompetition @relation("ParticipantCompetitionsInformation", fields: [participantCompetitionId], references: [id])
+  attempts                 Int                    @default(0)
+  completed                Boolean                @default(false)
+  points                   Int?
 }
 
 model Participant {
-  id            Int                    @id @default(autoincrement())
-  competitions  ParticipantCompetition[]
-  problems      ParticipantProblem[]
+  id           Int                      @id @default(autoincrement())
+  rut          String                   @unique
+  competitions ParticipantCompetition[]
+  problems     ParticipantProblem[]
 }

--- a/prisma/schema/schema.prisma
+++ b/prisma/schema/schema.prisma
@@ -4,7 +4,7 @@
 // Looking for ways to speed up your queries, or scale easily with your serverless or edge functions?
 // Try Prisma Accelerate: https://pris.ly/cli/accelerate-init
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
   previewFeatures = ["prismaSchemaFolder"]
 }
 

--- a/src/app/actions/competition.ts
+++ b/src/app/actions/competition.ts
@@ -7,9 +7,11 @@ import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { REVERSE_GRADE_TYPES } from "@/lib/constant/problem.conf";
 import { addRegisterFormSettingsToCompetitionById, createNewCompetition, getCompetitionById } from "@/lib/db/competition";
+import { createNewParticipant, addParticipantToCompetition, getParticipantCompetitionByRutAndCompetitionId } from "@/lib/db/participant";
 import { uploadBases, uploadPaymentFile } from "@/lib/s3";
 import { unformatCurrency } from "@/lib/utils";
 import { RegisterFormField, RegisterFormSettings } from "@/types/competition";
+import { normalizeRut } from "@/utils/rut";
 
 type CreateCompetitionResult = SubmissionResult | { status: 'success', competitionId: number };
 
@@ -200,5 +202,56 @@ export async function updateCompetitionRegisterForm(_prevState: unknown, formDat
     return { status: 'success' };
   } catch {
     return { status: 'error', error: { message: ['Error al crear el formulario de registro'] } };
+  }
+}
+
+export async function registerToCompetition(_prevState: unknown, formData: FormData, competitionId: number): Promise<SubmissionResult> {
+  try {
+    const competition = await getCompetitionById(competitionId);
+    const paymentFile = formData.get('paymentFile') as File;
+    let paymentFileUrl : string = '';
+    const rut = formData.get('rut') as string;
+    
+    if (paymentFile && paymentFile.size > 0) {
+      const fileBuffer = await paymentFile.arrayBuffer();
+      paymentFileUrl = await uploadPaymentFile(Buffer.from(fileBuffer), paymentFile.name, paymentFile.type, competitionId);
+    }
+    
+    if (!competition || !competition.registerFormSettings) {
+      return { 
+        status: 'error', 
+        error: { message: ['Competencia no encontrada o no cuenta con un formulario de registro'] }, 
+      };
+    }
+    
+    const registerFormSettings = competition.registerFormSettings as RegisterFormSettings;
+
+    const fields = registerFormSettings.fields.reduce((acc, field, index) => {
+      const value = formData.get(`field_${index}`);
+      return {
+        ...acc,
+        [field.name]: value,
+      };
+    }, {});
+
+    const participantInformation = {
+      ...fields,
+      paymentFile: paymentFileUrl,
+    };
+
+    const participant = await createNewParticipant(normalizeRut(rut));
+
+    const participantIsRegistered = await getParticipantCompetitionByRutAndCompetitionId(normalizeRut(rut), competitionId);
+
+    if (participantIsRegistered) {
+      return { status: 'error', error: { message: ['Ya estás registrado en esta competencia'] } };
+    }
+
+    await addParticipantToCompetition(competitionId, participantInformation, participant.id);
+
+    return { status: 'success' };
+
+  } catch {
+    return { status: 'error', error: { message: ['Error al registrar participante'] } };
   }
 }

--- a/src/app/actions/competition.ts
+++ b/src/app/actions/competition.ts
@@ -64,7 +64,6 @@ export async function createCompetitionRegisterForm(_prevState: unknown, formDat
   const competitionBases = formData.get('competitionBases') as File;
   const isPaymentToggleChecked = formData.get('isPaymentToggleChecked') as string;
   const registerFields = JSON.parse(formData.get('registerFields') as string) as RegisterFormField[];
-  const participantIdentifier = formData.get('participantIdentifier') as string;
 
   type PaymentFormData = {
     paymentRequired: boolean;
@@ -106,7 +105,6 @@ export async function createCompetitionRegisterForm(_prevState: unknown, formDat
     ...paymentFormData,
     competitionBasesFileUrl,
     fields: registerFields,
-    participantIdentifier,
   };
 
   try {
@@ -135,7 +133,7 @@ export async function updateCompetitionRegisterForm(_prevState: unknown, formDat
   const competitionBases = formData.get('competitionBases') as File;
   const isPaymentToggleChecked = formData.get('isPaymentToggleChecked') as string;
   const registerFields = JSON.parse(formData.get('registerFields') as string) as RegisterFormField[];
-  const participantIdentifier = formData.get('participantIdentifier') as string;
+
   type PaymentFormData = {
     paymentRequired: boolean;
     paymentUrl?: string;
@@ -195,7 +193,6 @@ export async function updateCompetitionRegisterForm(_prevState: unknown, formDat
     ...paymentFormData,
     competitionBasesFileUrl,
     fields: registerFields,
-    participantIdentifier,
   };
 
   try {

--- a/src/app/dashboard/competitions/[competitionId]/register-form/create/components/CreateCompetitionRegisterForm.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/register-form/create/components/CreateCompetitionRegisterForm.tsx
@@ -17,7 +17,7 @@ import FormInput from "@/components/ui/FormInput";
 import { FormSelect } from "@/components/ui/FormSelect";
 import SubmitButton from "@/components/ui/SubmitButton";
 import Toogle from "@/components/ui/Toogle";
-import { fieldTypeOptions, participantIdentifierOptions } from "@/lib/constant/competition.conf";
+import { fieldTypeOptions } from "@/lib/constant/competition.conf";
 
 import { createCompetitionRegisterFormSchema } from "../../schemas/CompetitionRegisterFormSchema";
 
@@ -38,7 +38,6 @@ export default function CreateCompetitionRegisterForm({ competition }: CreateCom
   const [currentFieldName, setCurrentFieldName] = useState<string>('');
   const [currentFieldType, setCurrentFieldType] = useState<string>('');
   const [price, setPrice] = useState<string>('');
-  const [participantIdentifier, setParticipantIdentifier] = useState<string>('');
 
   const [form, fields] = useForm({
     lastResult,
@@ -156,6 +155,7 @@ export default function CreateCompetitionRegisterForm({ competition }: CreateCom
           />
 
           <p className="text-lg text-gray-500">Datos del participante</p>
+          <p className="text-sm text-gray-500"> * Climbup pide el RUT del participante para poder registrarlos en la competencia.</p>
 
           <input
             type="hidden"
@@ -184,16 +184,6 @@ export default function CreateCompetitionRegisterForm({ competition }: CreateCom
               </button>
             </div>
           ))}
-          <FormSelect
-            label="Identificador del participante"
-            name={fields.participantIdentifier.name}
-            options={participantIdentifierOptions}
-            placeholder="Selecciona un identificador del participante"
-            required={false}
-            errors={fields.participantIdentifier.errors}
-            value={participantIdentifier}
-            onChange={(value) => setParticipantIdentifier(value)}
-          />
           <div className="flex flex-row items-end gap-4">
             <FormInput
               label="Nombre del campo"
@@ -206,7 +196,7 @@ export default function CreateCompetitionRegisterForm({ competition }: CreateCom
             <FormSelect
               label="Tipo de campo"
               name="currentFieldType"
-              options={fieldTypeOptions.filter((type) => type !== participantIdentifier)}
+              options={fieldTypeOptions}
               placeholder="Selecciona un tipo de campo"
               required={false}
               errors={undefined}

--- a/src/app/dashboard/competitions/[competitionId]/register-form/edit/components/EditCompetitionRegisterForm.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/register-form/edit/components/EditCompetitionRegisterForm.tsx
@@ -17,7 +17,7 @@ import FormInput from "@/components/ui/FormInput";
 import { FormSelect } from "@/components/ui/FormSelect";
 import SubmitButton from "@/components/ui/SubmitButton";
 import Toogle from "@/components/ui/Toogle";
-import { fieldTypeOptions, participantIdentifierOptions } from "@/lib/constant/competition.conf";
+import { fieldTypeOptions } from "@/lib/constant/competition.conf";
 import { RegisterFormSettings } from "@/types/competition";
 
 import { editCompetitionRegisterFormSchema } from "../../schemas/CompetitionRegisterFormSchema";
@@ -36,7 +36,6 @@ export default function EditCompetitionRegisterForm({ competition, basesUrl, pay
   const [price, setPrice] = useState<string>(registerFormSettings?.price ? registerFormSettings?.price : '');
   const [isPaymentToggleChecked, setIsPaymentToggleChecked] = useState<boolean>(registerFormSettings?.paymentType === 'file');
   const [paymentLink, setPaymentLink] = useState<string>(registerFormSettings?.paymentType === 'url' ? registerFormSettings?.paymentUrl ?? '' : '');
-  const [participantIdentifier, setParticipantIdentifier] = useState<string>(registerFormSettings?.participantIdentifier ?? '');
   const [lastResult, formAction] = useActionState(
     async (state: unknown, formData: FormData) => updateCompetitionRegisterForm(state, formData, competition.id),
     undefined,
@@ -204,16 +203,6 @@ export default function EditCompetitionRegisterForm({ competition, basesUrl, pay
               </button>
             </div>
           ))}
-          <FormSelect
-            label="Identificador del participante"
-            name={fields.participantIdentifier.name}
-            options={participantIdentifierOptions}
-            placeholder="Selecciona un identificador del participante"
-            required={false}
-            errors={fields.participantIdentifier.errors}
-            value={participantIdentifier}
-            onChange={(value) => setParticipantIdentifier(value)}
-          />
           <div className="flex flex-row items-end gap-4">
             <FormInput
               label="Nombre del campo"
@@ -226,7 +215,7 @@ export default function EditCompetitionRegisterForm({ competition, basesUrl, pay
             <FormSelect
               label="Tipo de campo"
               name="currentFieldType"
-              options={fieldTypeOptions.filter((type) => type !== participantIdentifier)}
+              options={fieldTypeOptions}
               placeholder="Selecciona un tipo de campo"
               required={false}
               errors={undefined}

--- a/src/app/dashboard/competitions/[competitionId]/register-form/schemas/CompetitionRegisterFormSchema.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/register-form/schemas/CompetitionRegisterFormSchema.tsx
@@ -10,7 +10,6 @@ export const createCompetitionRegisterFormSchema = z.object({
   paymentLink: z.string().url({ message: "El link de pago debe ser una URL válida" }).optional(),
   competitionBases: z.instanceof(File).optional(),
   isPaymentToggleChecked: z.string().optional(),
-  participantIdentifier: z.string({ message: "Identificador del participante requerido" }),
 }).refine(
   (data) => {
     if (data.isFree === 'false' && data.price === '$0') {
@@ -56,7 +55,6 @@ export const editCompetitionRegisterFormSchema = z.object({
   paymentLink: z.string().url({ message: "El link de pago debe ser una URL válida" }).optional(),
   competitionBases: z.instanceof(File).optional(),
   isPaymentToggleChecked: z.string().optional(),
-  participantIdentifier: z.string({ message: "Identificador del participante requerido" }),
 }).refine(
   (data) => {
     if (data.isFree === 'false' && data.price === '$0') {

--- a/src/app/register/[organizerId]/[competitionId]/components/RegisterForm.tsx
+++ b/src/app/register/[organizerId]/[competitionId]/components/RegisterForm.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useForm } from "@conform-to/react";
+import { parseWithZod } from "@conform-to/zod";
+import { CaretRight, FileText, CreditCard } from "@phosphor-icons/react";
+import { Competition, Organizer } from "@prisma/client";
+import { useRouter } from "next/navigation";
+import { useActionState, useEffect } from "react";
+import { toast } from "react-hot-toast";
+
+import { registerToCompetition } from "@/app/actions/competition";
+import { RutInput } from "@/components/RutInput";
+import FileInput from "@/components/ui/FileInput";
+import FormInput from "@/components/ui/FormInput";
+import SubmitButton from "@/components/ui/SubmitButton";
+import { RegisterFormSettings } from "@/types/competition";
+
+import { createRegisterFormSchema } from "../schemas/RegisterFormSchema";
+
+interface RegisterFormProps {
+  competition: Competition
+  organizer: Organizer;
+  paymentUrl?: string;
+  competitionBasesUrl?: string;
+}
+
+export default function RegisterForm({ competition, organizer, paymentUrl, competitionBasesUrl }: RegisterFormProps) {
+  const router = useRouter();
+  const [lastResult, formAction] = useActionState(
+    async (state: unknown, formData: FormData) => registerToCompetition(state, formData, competition.id),
+    undefined,
+  );
+
+  const registerFormSettings = competition.registerFormSettings as RegisterFormSettings;
+  
+  const [form, fields] = useForm({
+    lastResult,
+    onValidate({ formData }) {
+      const result = parseWithZod(formData, { 
+        schema: createRegisterFormSchema(registerFormSettings),
+      });
+      return result
+    },
+    shouldValidate: 'onBlur',
+    shouldRevalidate: 'onInput',
+  });
+
+  useEffect(() => {
+    if (lastResult?.status === 'success') {
+      toast.success('Registro completado correctamente');
+    } else if (lastResult?.status === 'error') {
+      toast.error(lastResult.error?.message?.[0] || 'Error al registrarse');
+    }
+  }, [lastResult, router, organizer, competition.id]);
+  return (
+    <div className="my-10 flex min-h-screen items-center justify-center">
+      <div className="w-full max-w-xl overflow-hidden rounded-xl shadow-lg transition-all">
+        <div className="bg-gradient-to-r from-primary/80 to-primary p-6 text-white">
+          <h1 className="text-2xl font-bold tracking-tight md:text-3xl">
+            {organizer.name}
+          </h1>
+          <p className="mt-1 text-lg font-medium md:text-xl">
+            {registerFormSettings.title}
+          </p>
+        </div>
+        
+        <div className="space-y-6 p-6 md:p-8">
+          <div className="dark:prose-invert prose max-w-none">
+            <p className="text-gray-600 dark:text-gray-300">
+              {registerFormSettings.description}
+            </p>
+          </div>
+
+          {competitionBasesUrl && (
+            <div className="flex items-center gap-3 rounded-lg p-4 transition-all">
+              <FileText className="size-5 text-primary" />
+              <a 
+                href={competitionBasesUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1 font-medium text-primary transition-all hover:text-primary/80"
+              >
+                Ver bases de la competencia
+                <CaretRight className="size-4" />
+              </a>
+            </div>
+          )}
+
+          <form id={form.id} action={formAction} onSubmit={form.onSubmit} className="space-y-5">
+            <div className="space-y-4">
+              <RutInput
+                errors={fields.rut?.errors}
+              />
+              
+              {registerFormSettings.fields.map((field, index) => (
+                <FormInput
+                  key={index}
+                  label={field.name}
+                  name={`field_${index}`}
+                  type={field.type === 'number' ? 'number' : 'text'}
+                  placeholder={`Ingrese ${field.name.toLowerCase()}`}
+                  errors={fields[`field_${index}` as keyof typeof fields]?.errors}
+                />
+              ))}
+            </div>
+
+            {registerFormSettings.paymentRequired && (
+              <div className="mt-8 border-t border-gray-200 pt-6 dark:border-gray-700">
+                <div className="space-y-4">
+                  <div className="flex items-center gap-2">
+                    <CreditCard className="size-5 text-primary" />
+                    <h2 className="text-lg font-semibold">Información de pago</h2>
+                  </div>
+
+                  <div className="flex flex-col gap-3 rounded-lg p-4">
+                    <div className="flex items-center justify-between">
+                      <span className="text-gray-600 dark:text-gray-300">Precio:</span>
+                      <span className="text-lg font-bold">
+                        ${new Intl.NumberFormat('es-CL').format(Number(registerFormSettings.price) || 0)} CLP
+                      </span>
+                    </div>
+                    
+                    {paymentUrl ? (
+                      <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+                        <p className="mb-2 text-sm text-gray-600 dark:text-gray-300">Datos de transferencia:</p>
+                        <a 
+                          href={paymentUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1 font-medium text-primary transition-all hover:text-primary/80"
+                        >
+                          Ver datos de transferencia
+                          <CaretRight className="size-4" />
+                        </a>
+                      </div>
+                    ) : (
+                      <div className="rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+                        <p className="mb-2 text-sm text-gray-600 dark:text-gray-300">Link de pago:</p>
+                        <a 
+                          href={registerFormSettings.paymentUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1 font-medium text-primary transition-all hover:text-primary/80"
+                        >
+                          Ir al link de pago
+                          <CaretRight className="size-4" />
+                        </a>
+                      </div>
+                    )}
+                  </div>
+                  <div>
+                    <FileInput 
+                      label="Subir comprobante de pago"
+                      name="paymentFile"
+                      errors={fields.paymentFile?.errors}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="pt-4">
+              <SubmitButton 
+                label="Registrarse"
+                loadingLabel="Registrando..."
+              />
+            </div>
+            <div className="mt-8 border-t border-gray-200 pt-6 dark:border-gray-700">
+              <p className="text-center text-sm text-gray-500 dark:text-gray-400">
+              Desarrollado por <span className="font-semibold">ClimbUp</span> © 2025
+              </p>
+            </div>
+          </form>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/register/[organizerId]/[competitionId]/page.tsx
+++ b/src/app/register/[organizerId]/[competitionId]/page.tsx
@@ -1,0 +1,38 @@
+import { notFound } from "next/navigation";
+
+import { getCompetitionById } from "@/lib/db/competition";
+import { getOrganizerById } from "@/lib/db/organizer";
+import { getSignedUrlForReading } from "@/lib/s3";
+import { RegisterFormSettings } from "@/types/competition";
+
+import RegisterForm from "./components/RegisterForm";
+
+interface RegisterPageProps {
+  params: Promise<{
+    organizerId: string;
+    competitionId: string;
+  }>;
+}
+export default async function RegisterPage(props: RegisterPageProps) {
+  const params = await props.params;
+  const competition = await getCompetitionById(parseInt(params.competitionId));
+  const organizer = await getOrganizerById(parseInt(params.organizerId));
+  let paymentUrl: string | undefined;
+  let competitionBasesUrl: string | undefined;
+
+  if (!competition || !organizer) {
+    notFound();
+  }
+
+  const registerFormSettings = competition.registerFormSettings as RegisterFormSettings;
+
+  if (registerFormSettings.paymentType === 'file') {
+    paymentUrl = await getSignedUrlForReading(registerFormSettings.paymentUrl as string);
+  }
+
+  if (registerFormSettings.competitionBasesFileUrl) {
+    competitionBasesUrl = await getSignedUrlForReading(registerFormSettings.competitionBasesFileUrl as string);
+  }
+
+  return <RegisterForm competition={competition} organizer={organizer} paymentUrl={paymentUrl} competitionBasesUrl={competitionBasesUrl} />;
+}

--- a/src/app/register/[organizerId]/[competitionId]/schemas/RegisterFormSchema.tsx
+++ b/src/app/register/[organizerId]/[competitionId]/schemas/RegisterFormSchema.tsx
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+import { RegisterFormSettings } from "@/types/competition";
+import { cleanRut, validateRut } from "@/utils/rut";
+
+export function createRegisterFormSchema(registerFormSettings: RegisterFormSettings) {
+  return z.object({
+    paymentFile: z.instanceof(File).optional().refine((file) => {
+      if (file instanceof File) {
+        return file.size > 0
+      } else if (file === null || file === undefined) {
+        return false
+      }
+      return true
+    }, {
+      message: 'Debes subir un comprobante de pago',
+    }),
+    ...Object.fromEntries(
+      registerFormSettings.fields.map((field, index) => [
+        `field_${index}`, 
+        z.string({ message: `Este campo es requerido` }),
+      ]),
+    ),
+    rut: z.string({ message: 'Este campo es requerido' }).refine(
+      (data) => {
+        if (data.length < 8) {
+          return false
+        }
+        const cleanedRut = cleanRut(data)
+        if (!validateRut(cleanedRut)) {
+          return false
+        }
+        return true
+      },
+      {
+        message: 'RUT inválido',
+      },
+    ),
+  })
+}
+
+export type RegisterFormSchema = z.infer<ReturnType<typeof createRegisterFormSchema>>;

--- a/src/lib/constant/competition.conf.ts
+++ b/src/lib/constant/competition.conf.ts
@@ -1,3 +1,1 @@
-export const fieldTypeOptions = ['Texto', 'Número', 'Email', 'Teléfono', 'Fecha', 'Hora', 'Checkbox', 'RUT']
-
-export const participantIdentifierOptions = ['RUT', 'Email', 'Teléfono']
+export const fieldTypeOptions = ['Texto', 'Número', 'Email', 'Teléfono', 'Fecha', 'Hora', 'Checkbox']

--- a/src/lib/db/organizer.ts
+++ b/src/lib/db/organizer.ts
@@ -1,5 +1,11 @@
 import prisma from "./prisma";
 
+export async function getOrganizerById(organizerId: number) {
+  return await prisma.organizer.findUnique({
+    where: { id: organizerId },
+  });
+}
+
 export async function getOrganizerNameById(organizerId: number) {
   const organizer = await prisma.organizer.findUnique({
     where: { id: organizerId },

--- a/src/lib/db/participant.ts
+++ b/src/lib/db/participant.ts
@@ -1,9 +1,40 @@
-import { ParticipantStatus } from "@prisma/client";
+import { Participant, ParticipantStatus } from "@prisma/client";
 
 import { ParticipantWithCompetitionInformation } from "@/types/participant";
 
 import { getLastCompetitionForOrganizer, getParticipantsCountForCompetitionByCompetitionId } from "./competition";
 import prisma from "./prisma";
+
+export async function createNewParticipant(rut: string): Promise<Participant> {
+  const existingParticipant = await prisma.participant.findFirst({
+    where: {
+      rut,
+    },
+  });
+
+  if (existingParticipant) {
+    return existingParticipant;
+  }
+  
+  const participant = await prisma.participant.create({
+    data: {
+      rut,
+    },
+  });
+
+  return participant;
+}
+
+export async function addParticipantToCompetition(competitionId: number, fields: Record<string, string>, participantId: number) {
+  await prisma.participantCompetition.create({
+    data: {
+      participantId,
+      status: ParticipantStatus.PENDING,
+      competitionId,
+      userInformation: fields,
+    },
+  });
+}
 
 export async function getParticipantsCountForOrganizer(organizerId: number) {
   const competitions = await prisma.competition.findMany({
@@ -80,4 +111,13 @@ export async function findParticipantById(id: number) {
   });
 
   return participant;
+}
+
+export async function getParticipantCompetitionByRutAndCompetitionId(rut: string, competitionId: number) {
+  return await prisma.participantCompetition.findFirst({
+    where: {
+      participant: { rut },
+      competitionId,
+    },
+  });
 }

--- a/src/types/competition.d.ts
+++ b/src/types/competition.d.ts
@@ -32,7 +32,6 @@ export type RegisterFormSettings = {
     paymentType?: 'file' | 'url';
     competitionBasesFileUrl?: string;
     fields: RegisterFormField[];
-    participantIdentifier: string;
 }
 
 


### PR DESCRIPTION
## Descripción 📝

Se agrega el form de registro basado en el que se creó para la competencia

## Resumen de los cambios 🛠

- Se agrega formulario de registro
- Se crea participantes de las competencias
- Se permiten pagos a traves de comprobantes de pago

## Comentarios 💬

Se eliminó el identificador de participante ya que se acordó pedir siempre el RUT para guardarlo y usarlo en futuras competencias. Se dejó una nota comentando esto a las organizadoras

## Screenshots 📸

![image](https://github.com/user-attachments/assets/d25710c6-672b-4dd7-a881-bb282cc76a68)

