### PR TITLE
Feat/integrate date-fns for consistent datetime formatting in competition views

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@prisma/client": "^6.1.0",
     "@tailwindcss/postcss": "^4.1.11",
     "bcrypt": "^5.1.1",
+    "date-fns": "^4.1.0",
     "framer-motion": "^12.7.4",
     "html5-qrcode": "^2.3.8",
     "next": "15.1.2",

--- a/src/app/dashboard/competitions/[competitionId]/components/CompetitionDetails.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/components/CompetitionDetails.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { format } from 'date-fns';
+
 import { StatusBadge } from "@/components/ui/StatusBadge";
 import { CompetitionWithOrganizer } from '@/types/competition';
 
@@ -15,7 +17,7 @@ export function CompetitionDetails( { competition }: CompetitionDetailsProps ) {
         <div className="space-y-2">
           <p><span className="font-bold">Código:</span> {competition.code}</p>
           <p><span className="font-bold">Ubicación:</span> {competition.location}</p>
-          <p><span className="font-bold">Fecha:</span> {new Date(competition.date).toLocaleDateString()}</p>
+          <p><span className="font-bold">Fecha:</span> {format(new Date(competition.date), 'dd/MM/yyyy, HH:mm')}</p>
           <p><span className="font-bold">Duración:</span> {competition.duration} minutos</p>
           <p><span className="font-bold">Organizador:</span> {competition.organizer.name}</p>
           <p><span className="font-bold">Estado:</span> <StatusBadge status={competition.status} /></p>

--- a/src/app/dashboard/components/RecentCompetitions.tsx
+++ b/src/app/dashboard/components/RecentCompetitions.tsx
@@ -1,4 +1,5 @@
 import { Competition } from "@prisma/client";
+import { format } from 'date-fns';
 import Link from "next/link";
 
 import { Collapse } from "@/components/ui/Collapse";
@@ -23,7 +24,7 @@ export default function RecentCompetitions({ competitions }: { competitions: Com
               {competitions.map((competition) => (
                 <tr key={competition.id}>
                   <td>{competition.name}</td>
-                  <td>{new Date(competition.date).toLocaleDateString()}</td>
+                  <td>{format(new Date(competition.date), 'dd/MM/yyyy, HH:mm')}</td>
                   <td>{competition.location}</td>
                   <td><StatusBadge status={competition.status} /></td>
                   <td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2206,6 +2206,11 @@ data-view-byte-offset@^1.0.1:
     es-errors "^1.3.0"
     is-data-view "^1.0.1"
 
+date-fns@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-4.1.0.tgz#64b3d83fff5aa80438f5b1a633c2e83b8a1c2d14"
+  integrity sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==
+
 debug@4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.3.7:
   version "4.4.0"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz"


### PR DESCRIPTION
## Descripción 📝
Se mejoro el formateo de fechas en CompetitionDetails y RecentCompetitions.

## Resumen de los cambios 🛠
Se usa la librería `date-fns`

## Screenshots 📸
<img width="2978" height="1230" alt="image" src="https://github.com/user-attachments/assets/812da1d7-c94f-445b-aeef-bc9f45757052" />

<img width="3024" height="1687" alt="image" src="https://github.com/user-attachments/assets/964e8e44-b7ec-404e-9d84-4886c3bbff8a" />
