### PR TITLE
Feat/add status badge component

### DIFF
--- a/src/app/dashboard/competitions/[competitionId]/components/CompetitionDetails.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/components/CompetitionDetails.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { StatusBadge } from "@/components/ui/StatusBadge";
 import { CompetitionWithOrganizer } from '@/types/competition';
 
 interface CompetitionDetailsProps {
@@ -17,6 +18,7 @@ export function CompetitionDetails( { competition }: CompetitionDetailsProps ) {
           <p><span className="font-bold">Fecha:</span> {new Date(competition.date).toLocaleDateString()}</p>
           <p><span className="font-bold">Duración:</span> {competition.duration} minutos</p>
           <p><span className="font-bold">Organizador:</span> {competition.organizer.name}</p>
+          <p><span className="font-bold">Estado:</span> <StatusBadge status={competition.status} /></p>
         </div>
       </div>
     </div>

--- a/src/app/dashboard/components/RecentCompetitions.tsx
+++ b/src/app/dashboard/components/RecentCompetitions.tsx
@@ -20,15 +20,15 @@ export default function RecentCompetitions({ competitions }: { competitions: Com
               </tr>
             </thead>
             <tbody>
-              {competitions.map((comp) => (
-                <tr key={comp.id}>
-                  <td>{comp.name}</td>
-                  <td>{new Date(comp.date).toLocaleDateString()}</td>
-                  <td>{comp.location}</td>
-                  <td><StatusBadge status={comp.status} /></td>
+              {competitions.map((competition) => (
+                <tr key={competition.id}>
+                  <td>{competition.name}</td>
+                  <td>{new Date(competition.date).toLocaleDateString()}</td>
+                  <td>{competition.location}</td>
+                  <td><StatusBadge status={competition.status} /></td>
                   <td>
                     <Link 
-                      href={`dashboard/competitions/${comp.id}`}
+                      href={`dashboard/competitions/${competition.id}`}
                       className="btn btn-primary btn-sm"
                     >
                       Ver competencia

--- a/src/app/dashboard/components/RecentCompetitions.tsx
+++ b/src/app/dashboard/components/RecentCompetitions.tsx
@@ -2,6 +2,7 @@ import { Competition } from "@prisma/client";
 import Link from "next/link";
 
 import { Collapse } from "@/components/ui/Collapse";
+import { StatusBadge } from "@/components/ui/StatusBadge";
 
 export default function RecentCompetitions({ competitions }: { competitions: Competition[] }) {
   return (
@@ -14,6 +15,7 @@ export default function RecentCompetitions({ competitions }: { competitions: Com
                 <th>Nombre</th>
                 <th>Fecha</th>
                 <th>Ubicación</th>
+                <th>Estado</th>
                 <th>Acción</th>
               </tr>
             </thead>
@@ -23,6 +25,7 @@ export default function RecentCompetitions({ competitions }: { competitions: Com
                   <td>{comp.name}</td>
                   <td>{new Date(comp.date).toLocaleDateString()}</td>
                   <td>{comp.location}</td>
+                  <td><StatusBadge status={comp.status} /></td>
                   <td>
                     <Link 
                       href={`dashboard/competitions/${comp.id}`}

--- a/src/components/ui/StatusBadge.tsx
+++ b/src/components/ui/StatusBadge.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { CompetitionStatus } from "@prisma/client";
+
+import { COMPETITION_STATUS_LABELS, COMPETITION_STATUS_COLORS } from "@/lib/constant/competition.conf";
+
+interface StatusBadgeProps {
+  status: CompetitionStatus;
+}
+
+export function StatusBadge({ status }: StatusBadgeProps) {
+  return (
+    <div className={`badge ${COMPETITION_STATUS_COLORS[status]}`}>
+      {COMPETITION_STATUS_LABELS[status]}
+    </div>
+  );
+}

--- a/src/lib/constant/competition.conf.ts
+++ b/src/lib/constant/competition.conf.ts
@@ -1,1 +1,17 @@
+import { CompetitionStatus } from "@prisma/client";
+
 export const fieldTypeOptions = ['Texto', 'Número', 'Email', 'Teléfono', 'Fecha', 'Hora', 'Checkbox']
+
+export const COMPETITION_STATUS_LABELS: Record<CompetitionStatus, string> = {
+  NOT_STARTED: "No iniciada",
+  IN_PROGRESS: "En progreso",
+  FINISHED: "Finalizada",
+  CANCELLED: "Cancelada",
+};
+
+export const COMPETITION_STATUS_COLORS: Record<CompetitionStatus, string> = {
+  NOT_STARTED: "badge-neutral",
+  IN_PROGRESS: "badge-warning",
+  FINISHED: "badge-success",
+  CANCELLED: "badge-error",
+};


### PR DESCRIPTION
## Descripción 📝

**Como** usuario administrador del sistema ClimbUp, **necesito** poder visualizar rápidamente el estado actual de las competiciones para tener una mejor comprensión del progreso y estado de cada evento. Esto me permitirá identificar de manera eficiente qué competiciones están activas, finalizadas, canceladas o aún no han comenzado, mejorando la gestión y seguimiento de los eventos.

## Resumen de los cambios 🛠

### Commit 49acd62: Implementación de badges de estado para competiciones
- **Nuevo componente**: Creado `StatusBadge.tsx` que muestra el estado de las competiciones con colores distintivos
- **Configuración de estados**: Agregadas constantes en `competition.conf.ts` para etiquetas y colores de estados:
  - No iniciada (neutral)
  - En progreso (warning/amarillo)
  - Finalizada (success/verde)
  - Cancelada (error/rojo)
- **Integración en componentes**: 
  - Agregada columna "Estado" en la tabla de `RecentCompetitions`
  - Incluido badge de estado en `CompetitionDetails`
- **Mejora de UX**: Los usuarios ahora pueden identificar visualmente el estado de cada competición

### Commit 411d847: Refactoring de legibilidad de código
- **Mejora de nomenclatura**: Renombrada variable `comp` a `competition` en `RecentCompetitions.tsx`
- **Mejor legibilidad**: El código es más descriptivo y fácil de entender para futuros desarrolladores
- **Consistencia**: Mantiene un estándar de nomenclatura más claro en toda la aplicación



## Screenshots 📸
<img width="1866" height="555" alt="image" src="https://github.com/user-attachments/assets/83ac3296-4579-4084-b399-60af0971868c" />
<img width="1897" height="929" alt="image" src="https://github.com/user-attachments/assets/41f1afb8-9791-4b53-b6eb-c36977b8a28a" />

