### PR TITLE
chore: change duration column header from hours to minutes in competiti…

### DIFF
--- a/src/app/dashboard/competitions/components/CompetitionsList.tsx
+++ b/src/app/dashboard/competitions/components/CompetitionsList.tsx
@@ -14,7 +14,7 @@ export default function CompetitionsList({ competitions }: CompetitionsListProps
             <th>Nombre</th>
             <th>Fecha</th>
             <th>Ubicación</th>
-            <th>Duración (hrs)</th>
+            <th>Duración (minutos)</th>
             <th>Código</th>
             <th>Acciones</th>
           </tr>


### PR DESCRIPTION
## Descripción 📝
Se cambia "hrs" por "minutos" en nombre de columna en http://localhost:3000/dashboard/competitions

## Screenshots 📸
**Antes:**
![duracion compe antes](https://github.com/user-attachments/assets/cab5ea8d-f51c-4a2f-8690-2d5476722e0d)

**Después:**
<img width="1915" height="745" alt="image" src="https://github.com/user-attachments/assets/06a8acbc-0527-4c70-b8df-e2e7220d62db" />
