### PR TITLE
feat: add judges management button to competition dashboard

### DIFF
--- a/src/app/dashboard/competitions/[competitionId]/page.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/page.tsx
@@ -59,6 +59,7 @@ export default async function CompetitionPage(props: CompetitionPageProps) {
             <div className="flex gap-2">
               <Link href={getRedirectToRegisterForm()} className="btn btn-primary">{competition.registerFormSettings ? 'Editar formulario de registro' : 'Crear formulario de registro'}</Link>
               <Link href={`/dashboard/competitions/${competition.id}/edit`} className="btn btn-primary">Editar</Link>
+              <Link href={`/dashboard/competitions/manage/${competition.id}/judges`} className="btn btn-secondary">Gestionar Jueces</Link>
             </div>
           </div>
           


### PR DESCRIPTION
## Descripción 📝
Anteriormente existía la ruta para **Gestionar Jueces** _(.../dashboard/competitions/manage/<competition_id>/judges)_, pero no había ningún botón en la aplicación para llegar a esta vista. Por esta razón, se creó dicho botón en la vista de detalle de una competencia. 

## Screenshots 📸
<img width="2990" height="1605" alt="image" src="https://github.com/user-attachments/assets/b242d175-7a66-4fb5-8c5a-d3064bc8d67e" />
<img width="3024" height="1418" alt="image" src="https://github.com/user-attachments/assets/1c79f898-7a88-4689-96b2-2225e3f19d0b" />
