### PR TITLE
feat: add manage problems link to ProblemsList component

### DIFF
--- a/src/app/dashboard/competitions/[competitionId]/components/ProblemsList.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/components/ProblemsList.tsx
@@ -2,16 +2,23 @@
 
 import { NotePencil } from "@phosphor-icons/react";
 import { Problem } from "@prisma/client";
+import Link from "next/link";
 
 import { Collapse } from "@/components/ui/Collapse";
 
 interface ProblemsListProps {
   problems: Problem[];
+  competitionId?: number;
 }
 
-export function ProblemsList({ problems }: ProblemsListProps) {
+export function ProblemsList({ problems, competitionId }: ProblemsListProps) {
   return (
     <Collapse title="Problemas">
+      {competitionId && (
+        <div className="mb-4 flex justify-end">
+          <Link href={`/dashboard/competitions/manage/${competitionId}/problems`} className="btn btn-primary">Gestionar problemas</Link>
+        </div>
+      )}
       <div className="overflow-x-auto">
         <table className="table table-zebra w-full">
           <thead>

--- a/src/app/dashboard/competitions/[competitionId]/page.tsx
+++ b/src/app/dashboard/competitions/[competitionId]/page.tsx
@@ -77,7 +77,7 @@ export default async function CompetitionPage(props: CompetitionPageProps) {
 
           <div className="divider"></div>
           
-          <ProblemsList problems={competition.problems} />
+          <ProblemsList problems={competition.problems} competitionId={competition.id} />
 
           <div className="divider"></div>
           


### PR DESCRIPTION
## Descripción 📝
Anteriormente existía la ruta para **Gestionar Problemas** _(.../dashboard/competitions/manage/<competition_id>/problems)_, pero no había ningún botón en la aplicación para llegar a esta vista. Por esta razón, se creó dicho botón en la vista de detalle de una competencia. 

## Screenshots 📸
<img width="2976" height="1803" alt="image" src="https://github.com/user-attachments/assets/2b515a32-1c11-479d-9871-3f062ebbb306" />
<img width="3024" height="1806" alt="image" src="https://github.com/user-attachments/assets/75218ef2-8169-4c32-af6a-4e0fd38958ed" />
