### PR TITLE
refactor: improve FormSelect styling

### DIFF
--- a/src/components/ui/FormSelect.tsx
+++ b/src/components/ui/FormSelect.tsx
@@ -11,27 +11,28 @@ interface FormSelectProps {
 
 export function FormSelect({ label, name, placeholder, options, required, errors, value, onChange }: FormSelectProps) {
   return (
-    <label className="form-control w-full max-w-xs">
-      <div className="label">
+    <div className="form-control">
+      <label htmlFor={name} className="label">
         <span className="label-text">{label}</span>
-      </div>
+      </label>
       <select
-        className={`select select-bordered ${errors ? 'select-error' : ''}`}
+        id={name}
         name={name}
+        className={`select select-bordered w-full ${errors ? 'select-error' : ''}`}
         value={value}
         onChange={(e) => onChange?.(e.target.value)}
         required={required}
       >
-        <option>{placeholder}</option>
+        <option value="">{placeholder}</option>
         {options.map((option) => (
           <option key={option} value={option}>{option}</option>
         ))}
       </select>
       {errors?.[0] && (
-        <div className="label">
-          <span className="label-text-alt">{errors?.[0]}</span>
-        </div>
+        <label className="label">
+          <span className="label-text-alt text-error">{errors?.[0]}</span>
+        </label>
       )}
-    </label>
+    </div>
   );
 }


### PR DESCRIPTION
## Descripción 📝
Este PR mejora la estructura y diseño del componente `FormSelect` para que muestre el label arriba del select, en lugar de en la misma línea. El cambio alinea el diseño con el patrón utilizado en otros componentes de formulario como `FormInput`, lo que proporciona una experiencia de usuario más consistente en toda la aplicación.

## Screenshots 📸
**ANTES:**
<img width="3006" height="1486" alt="image" src="https://github.com/user-attachments/assets/3c7044d0-e9ee-47b9-abdd-71aeb47dcda5" />

**DESPUÉS:**
<img width="3000" height="1572" alt="image" src="https://github.com/user-attachments/assets/8cb07353-a4af-41f7-b70c-f4856597b0ce" />
