### PR TITLE
Feat/add judge to all problems

### DIFF
--- a/src/app/actions/judge.ts
+++ b/src/app/actions/judge.ts
@@ -121,7 +121,7 @@ export async function assignJudgeToProblem(_prevState: unknown, formData: FormDa
     const problemId = Number(formData.get('problemId'));
     const action = formData.get('action');
 
-    if (!problemId) {
+    if (!problemId || !judgeId) {
       return { status: 'error', error: { message: ['Datos inválidos'] } };
     }
 
@@ -130,10 +130,7 @@ export async function assignJudgeToProblem(_prevState: unknown, formData: FormDa
       revalidatePath('/dashboard/competitions');
       return { status: 'success', action: 'remove' };
     } 
-    if (!judgeId) {
-      return { status: 'error', error: { message: ['Datos inválidos'] } };
-    }
-
+    
     await linkProblemWithJudge(problemId, judgeId);
 
     revalidatePath('/dashboard/competitions');

--- a/src/app/actions/judge.ts
+++ b/src/app/actions/judge.ts
@@ -7,6 +7,7 @@ import { revalidatePath } from 'next/cache';
 import { getCompetitionById, getCompetitionsByJudgeId } from "@/lib/db/competition";
 import { createJudge, getJudgeByEmail, getJudgeCompetitionByCompetitionId, linkJudgeWithCompetition, removeJudgeFromCompetitionById, removeJudgeFromProblem } from "@/lib/db/judge";
 import { getOrganizerNameById } from "@/lib/db/organizer";
+import prisma from "@/lib/db/prisma";
 import { linkProblemWithJudge } from "@/lib/db/problem";
 
 type JudgeValidationResult = SubmissionResult & {
@@ -139,5 +140,31 @@ export async function assignJudgeToProblem(_prevState: unknown, formData: FormDa
     return { status: 'success', action: 'assign' };
   } catch {
     return { status: 'error', error: { message: ['Error al gestionar juez del problema'] } };
+  }
+}
+
+export async function assignJudgeToAllProblems(_prevState: unknown, formData: FormData): Promise<AssignJudgeResult> {
+  try {
+    const judgeId = Number(formData.get('judgeId'));
+    const competitionId = Number(formData.get('competitionId'));
+    
+    if (!judgeId || !competitionId) {
+      return { status: 'error', error: { message: ['Datos inválidos'] } };
+    }
+
+    // Obtener todos los problemas de la competencia
+    const problems = await prisma.problem.findMany({
+      where: { competitionId },
+    });
+
+    // Asignar el juez a cada problema
+    for (const problem of problems) {
+      await linkProblemWithJudge(problem.id, judgeId);
+    }
+
+    revalidatePath('/dashboard/competitions');
+    return { status: 'success', action: 'assign' };
+  } catch {
+    return { status: 'error', error: { message: ['Error al asignar juez a todos los problemas'] } };
   }
 }

--- a/src/app/dashboard/competitions/manage/[competitionId]/problems/components/AssignJudgeToAllDialog.tsx
+++ b/src/app/dashboard/competitions/manage/[competitionId]/problems/components/AssignJudgeToAllDialog.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import { Judge } from '@prisma/client';
+import React, { useTransition } from 'react';
+
+import { ProblemWithJudges } from '@/types/problem';
+
+interface AssignJudgeToAllDialogProps {
+  judges: Judge[];
+  problems: ProblemWithJudges[];
+  competitionId: number;
+  onConfirm: (e: React.FormEvent) => void;
+}
+
+export default function AssignJudgeToAllDialog({ 
+  judges, 
+  problems,
+  competitionId,
+  onConfirm, 
+}: AssignJudgeToAllDialogProps) {
+  const [isPending, startTransition] = useTransition();
+  
+  const availableJudges = judges.filter(judge => 
+    !problems.every(problem => 
+      problem.judges.some(j => j.id === judge.id),
+    ),
+  );
+
+  function handleSubmit(e: React.FormEvent) {
+    startTransition(() => {
+      onConfirm(e);
+    });
+  }
+
+  return (
+    <dialog id="assign_judge_to_all_modal" className="modal">
+      <div className="modal-box">
+        <h3 className="mb-4 text-lg font-bold">Asignar Juez a Todos los Problemas</h3>
+        <p className="mb-4 text-sm text-gray-600">
+          Esta acción asignará el juez seleccionado a todos los problemas de la competencia.
+        </p>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <input type="hidden" name="competitionId" value={competitionId} />
+          <div className="form-control">
+            <label htmlFor="judge-all-select" className="label">
+              <span className="label-text">Seleccionar Juez</span>
+            </label>
+            {availableJudges.length > 0 ? (
+              <select id="judge-all-select" name="judgeId" className="select select-bordered w-full">
+                <option value="">Seleccione un juez</option>
+                {availableJudges.map((judge) => (
+                  <option key={judge.id} value={judge.id}>
+                    {judge.email}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <p className="text-sm italic text-gray-500">No hay jueces disponibles para asignar o todos los jueces ya están asignados a todos los problemas</p>
+            )}
+          </div>
+          <div className="modal-action">
+            {availableJudges.length > 0 && (
+              <button 
+                type="submit" 
+                className="btn btn-primary"
+                disabled={isPending}
+              >
+                {isPending ? 'Asignando...' : 'Confirmar'}
+              </button>
+            )}
+            <button
+              type="button"
+              className="btn btn-ghost"
+              onClick={() => {
+                (document.getElementById('assign_judge_to_all_modal') as HTMLDialogElement)?.close();
+              }}
+            >
+              {availableJudges.length > 0 ? 'Cancelar' : 'Cerrar'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </dialog>
+  );
+}

--- a/src/app/dashboard/competitions/manage/[competitionId]/problems/components/ManageProblems.tsx
+++ b/src/app/dashboard/competitions/manage/[competitionId]/problems/components/ManageProblems.tsx
@@ -5,12 +5,13 @@ import { useRouter } from 'next/navigation';
 import React, { useActionState } from 'react';
 import { toast } from 'react-hot-toast';
 
-import { assignJudgeToProblem } from '@/app/actions/judge';
+import { assignJudgeToProblem, assignJudgeToAllProblems } from '@/app/actions/judge';
 import { deleteProblem } from '@/app/actions/problem';
 import ConfirmDialog from '@/components/ui/ConfirmDialog';
 import { ProblemWithJudges } from '@/types/problem';
 
 import AssignJudgeDialog from './AssignJudgeDialog';
+import AssignJudgeToAllDialog from './AssignJudgeToAllDialog';
 import ProblemsTable from './ProblemsTable';
 
 interface ManageProblemsProps {
@@ -25,6 +26,7 @@ export default function ManageProblems({ competitionId, problems, judges }: Mana
 
   const [lastResult, formAction] = useActionState(deleteProblem, undefined);
   const [lastAssignResult, assignFormAction] = useActionState(assignJudgeToProblem, undefined);
+  const [lastAssignAllResult, assignAllFormAction] = useActionState(assignJudgeToAllProblems, undefined);
 
   React.useEffect(() => {
     if (lastResult?.status === 'success') {
@@ -47,6 +49,15 @@ export default function ManageProblems({ competitionId, problems, judges }: Mana
       toast.error(lastAssignResult.error?.message?.[0] || 'Error al asignar juez');
     }
   }, [lastAssignResult]);
+  
+  React.useEffect(() => {
+    if (lastAssignAllResult?.status === 'success') {
+      toast.success('Juez asignado a todos los problemas correctamente');
+      (document.getElementById('assign_judge_to_all_modal') as HTMLDialogElement)?.close();
+    } else if (lastAssignAllResult?.status === 'error') {
+      toast.error(lastAssignAllResult.error?.message?.[0] || 'Error al asignar juez a todos los problemas');
+    }
+  }, [lastAssignAllResult]);
 
   function handleSkip() {
     router.push(`/dashboard/competitions`);
@@ -82,6 +93,10 @@ export default function ManageProblems({ competitionId, problems, judges }: Mana
     setSelectedProblemId(problemId);
     (document.getElementById('assign_judge_modal') as HTMLDialogElement)?.showModal();
   }
+  
+  function handleAssignJudgeToAllClick() {
+    (document.getElementById('assign_judge_to_all_modal') as HTMLDialogElement)?.showModal();
+  }
 
   function handleConfirmAssign(e: React.FormEvent) {
     e.preventDefault();
@@ -90,6 +105,13 @@ export default function ManageProblems({ competitionId, problems, judges }: Mana
         assignFormAction(new FormData(e.target as HTMLFormElement));
       });
     }
+  }
+  
+  function handleConfirmAssignAll(e: React.FormEvent) {
+    e.preventDefault();
+    React.startTransition(() => {
+      assignAllFormAction(new FormData(e.target as HTMLFormElement));
+    });
   }
 
   function handleRemoveJudge(problemId: number, judgeId: number) {
@@ -108,6 +130,25 @@ export default function ManageProblems({ competitionId, problems, judges }: Mana
         <div className="card-body">
           <h2 className="card-title mb-6 text-2xl">Gestionar Problemas</h2>
           
+          <div className="flex gap-2 flex-wrap mb-6">
+            <button
+              type="button"
+              className="btn btn-secondary"
+              onClick={goToAddProblemForm}
+            >
+              Agregar Problema
+            </button>
+            {judges.length > 0 && problems.length > 0 && (
+              <button
+                type="button"
+                className="btn btn-primary"
+                onClick={handleAssignJudgeToAllClick}
+              >
+                Asignar Juez a Todos los Problemas
+              </button>
+            )}
+          </div>
+          
           <div className="space-y-4">
             <ProblemsTable
               problems={problems}
@@ -119,13 +160,6 @@ export default function ManageProblems({ competitionId, problems, judges }: Mana
           </div>
 
           <div className="mt-6 flex flex-col gap-4">
-            <button
-              type="button"
-              className="btn btn-secondary"
-              onClick={goToAddProblemForm}
-            >
-              Agregar Problema
-            </button>
 
             <div className="flex justify-between">
               <button
@@ -174,6 +208,13 @@ export default function ManageProblems({ competitionId, problems, judges }: Mana
         judges={judges}
         problems={problems}
         onConfirm={handleConfirmAssign}
+      />
+      
+      <AssignJudgeToAllDialog
+        judges={judges}
+        problems={problems}
+        competitionId={competitionId}
+        onConfirm={handleConfirmAssignAll}
       />
     </div>
   );


### PR DESCRIPTION
## Descripción 📝

Implementación de funcionalidad para asignar jueces a todos los problemas de una competencia de manera simultánea, mejorando la eficiencia en la gestión de jueces y problemas.

## Resumen de los cambios 🛠

- Creación de una nueva función `assignJudgeToAllProblems` en el servidor para asignar un juez a todos los problemas de una competencia
- Implementación de un nuevo componente `AssignJudgeToAllDialog` que muestra solo los jueces que no están asignados a todos los problemas
- Adición de un botón "Asignar Juez a Todos los Problemas" en la parte superior de la página de gestión de problemas
- Los botones de acción se han movido a la parte superior para mejorar la accesibilidad cuando hay muchos problemas

## Comentarios 💬
- El filtro implementado en `AssignJudgeToAllDialog` asegura que solo se muestren jueces que no están asignados a todos los problemas, evitando asignaciones redundantes
- La interfaz de usuario muestra mensajes claros cuando no hay jueces disponibles para asignar
- Se mantiene la consistencia con el flujo existente de asignación individual de jueces a problemas

## Screenshots 📸

https://github.com/user-attachments/assets/b84b1b29-7ba1-46fd-9483-d15b574fef26

