### PR TITLE
feat: sort problems by max points in ascending order in ProblemsTable component

### DIFF
--- a/src/app/dashboard/competitions/manage/[competitionId]/problems/components/ProblemsTable.tsx
+++ b/src/app/dashboard/competitions/manage/[competitionId]/problems/components/ProblemsTable.tsx
@@ -11,8 +11,10 @@ interface ProblemsTableProps {
 }
 
 export default function ProblemsTable({ problems, handleRemoveJudge, handleAssignJudgeClick, handleDeleteClick, judges }: ProblemsTableProps) {
+  const sortedProblems = [...problems].sort((a, b) => a.maxPoints - b.maxPoints);
+  
   return (
-    problems.map((problem) => (
+    sortedProblems.map((problem) => (
       <div key={problem.id} className="flex items-center justify-between rounded-lg border p-4">
         <div className="flex-1">
           <h3 className="font-semibold">{problem.name}</h3>


### PR DESCRIPTION
## Descripción 📝

Ordenamiento de problemas por puntaje máximo en la tabla de problemas para mejorar la visualización y organización.

## Resumen de los cambios 🛠

- Se modificó el componente `ProblemsTable.tsx` para ordenar los problemas por `maxPoints` de forma ascendente (de menor a mayor)

## Comentarios 💬

Este cambio facilita la visualización de problemas según su dificultad, permitiendo a los organizadores ver primero los problemas con menor puntaje y progresivamente los de mayor valor.

## Screenshots 📸
<img width="2980" height="1811" alt="image" src="https://github.com/user-attachments/assets/bda5d7aa-c661-4cf5-aa47-672a9ef54f67" />
