### PR TITLE
Feat: add settings option to change organizer name

### DIFF
--- a/src/app/actions/organizer.ts
+++ b/src/app/actions/organizer.ts
@@ -1,0 +1,57 @@
+'use server';
+
+import { SubmissionResult } from "@conform-to/react";
+import { Organizer } from "@prisma/client";
+import { revalidatePath } from 'next/cache';
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth";
+import { getOrganizerById, updateOrganizerName } from '@/lib/db/organizer';
+
+type OrganizerSubmissionResult = SubmissionResult & {
+  data?: Organizer;
+};
+
+export async function getOrganizerSettings(): Promise<OrganizerSubmissionResult> {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id || !session?.user?.organizerId) {
+      return { status: 'error', error: { message: ['No se ha iniciado sesión'] } };
+    }
+    
+    const organizer = await getOrganizerById(session.user.organizerId);
+    
+    if (!organizer) {
+      return { status: 'error', error: { message: ['No se encontró ningún organizador'] } };
+    }
+
+    return { status: 'success', data: organizer };
+  } catch {
+    return { status: 'error', error: { message: ['Error al obtener la configuración del organizador'] } };
+  }
+}
+
+export async function updateOrganizerSettings(formData: FormData): Promise<OrganizerSubmissionResult> {
+  try {
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user?.id || !session?.user?.organizerId) {
+      return { status: 'error', error: { message: ['No se ha iniciado sesión'] } };
+    }
+    
+    const name = formData.get('name') as string;
+    
+    if (!name) {
+      return { status: 'error', error: { message: ['Falta el nombre del organizador'] } };
+    }
+    
+    const updatedOrganizer = await updateOrganizerName(session.user.organizerId, name);
+
+    revalidatePath('/dashboard/settings');
+    
+    return { status: 'success', data: updatedOrganizer };
+  } catch {
+    return { status: 'error', error: { message: ['Error al actualizar la configuración del organizador'] } };
+  }
+}

--- a/src/app/dashboard/settings/components/OrganizerSettingsForm.tsx
+++ b/src/app/dashboard/settings/components/OrganizerSettingsForm.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import { X } from '@phosphor-icons/react';
+import { useRouter } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import { toast } from 'react-hot-toast';
+
+import { getOrganizerSettings, updateOrganizerSettings } from '@/app/actions/organizer';
+import FormInput from '@/components/ui/FormInput';
+import SubmitButton from '@/components/ui/SubmitButton';
+
+type Organizer = {
+  id: number;
+  name: string;
+};
+
+export default function OrganizerSettingsForm() {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [organizer, setOrganizer] = useState<Organizer | null>(null);
+
+  useEffect(() => {
+    async function fetchOrganizer() {
+      try {
+        const result = await getOrganizerSettings();
+        if (result.status === 'error') {
+          throw new Error(result.error?.message?.[0] || 'Error desconocido');
+        }
+        if (result.status === 'success' && result.data) {
+          setOrganizer(result.data);
+        }
+      } catch (error: unknown) {
+        const errorMessage = error instanceof Error ? error.message : 'Error desconocido';
+        toast.error(`No se pudo cargar la configuración del organizador: ${errorMessage}`);
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    fetchOrganizer();
+  }, []);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (!organizer) return;
+    
+    const { name, value } = e.target;
+    setOrganizer({ ...organizer, [name]: value });
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!organizer) return;
+    
+    setSaving(true);
+    try {
+      const formData = new FormData(e.currentTarget);
+      const result = await updateOrganizerSettings(formData);
+
+      if (result.status === 'error') {
+        throw new Error(result.error?.message?.[0] || 'Error desconocido');
+      }
+
+      toast.success('Nombre del organizador actualizado correctamente');
+      router.refresh();
+    } catch (error: unknown) {
+      const errorMessage = error instanceof Error ? error.message : 'Error desconocido';
+      toast.error(`No se pudo actualizar el nombre del organizador: ${errorMessage}`);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center items-center h-40">
+        <span className="loading loading-spinner loading-lg text-primary"></span>
+      </div>
+    );
+  }
+
+  if (!organizer) {
+    return (
+      <div className="alert alert-error">
+        <X size={24} weight="bold" />
+        <span>No se pudo cargar la información del organizador</span>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <h2 className="text-xl font-semibold">Información General</h2>
+      
+      <FormInput
+        label="Nombre del Organizador"
+        name="name"
+        type="text"
+        value={organizer.name}
+        onChange={handleChange}
+        required
+      />
+
+      <div className="flex justify-end gap-2 pt-4">
+        <button
+          type="button"
+          className="btn btn-outline"
+          onClick={() => router.back()}
+          disabled={saving}
+        >
+          Cancelar
+        </button>
+        <SubmitButton 
+          label="Guardar Cambios"
+          loadingLabel="Guardando..."
+          disabled={saving}
+        />
+      </div>
+    </form>
+  );
+}

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -1,0 +1,14 @@
+import OrganizerSettingsForm from './components/OrganizerSettingsForm';
+
+export default function SettingsPage() {
+  return (
+    <div className="container mx-auto p-4">
+      <div className="card bg-base-100 shadow-xl">
+        <div className="card-body">
+          <h1 className="card-title text-2xl mb-6">Configuración del Organizador</h1>
+          <OrganizerSettingsForm />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/Navbar.tsx
+++ b/src/components/ui/Navbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { List, SignOut } from "@phosphor-icons/react";
+import { List, SignOut, Gear } from "@phosphor-icons/react";
 import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -37,6 +37,7 @@ export default function Navbar({ organizerName, superAdmin }: NavbarProps) {
                 <li><Link href="/dashboard/admin/manage" onClick={() => setIsOpen(false)}>Administradores</Link></li>
               )}
               <li><Link href="/dashboard/judges" onClick={() => setIsOpen(false)}>Jueces</Link></li>
+              <li><Link href="/dashboard/settings" onClick={() => setIsOpen(false)} className="flex items-center gap-2">Configuración <Gear size={18}/></Link></li>
             </ul>
           )}
         </div>

--- a/src/components/ui/SubmitButton.tsx
+++ b/src/components/ui/SubmitButton.tsx
@@ -4,7 +4,7 @@ export default function SubmitButton({ label, loadingLabel, disabled }: { label:
   const { pending } = useFormStatus();
 
   return (
-    <div className="form-control mt-6">
+    <div className="form-control">
       <button type="submit" className="btn btn-primary w-full" disabled={pending || disabled}>
         {pending ? loadingLabel : label}
       </button>

--- a/src/lib/db/organizer.ts
+++ b/src/lib/db/organizer.ts
@@ -24,3 +24,10 @@ export async function getOrganizerByName(name: string) {
     where: { name },
   });
 }
+
+export async function updateOrganizerName(organizerId: number, name: string) {
+  return await prisma.organizer.update({
+    where: { id: organizerId },
+    data: { name },
+  });
+}


### PR DESCRIPTION
## Descripción 📝

Este PR añade la funcionalidad para que los administradores puedan editar el nombre de su organización desde una nueva página de configuración.

## Resumen de los cambios 🛠

- Nueva página de configuración en `/dashboard/settings`
- Formulario para editar el nombre del organizador
- Server Actions para manejar la actualización
- Enlace de configuración en la barra de navegación


## Screenshots 📸

https://github.com/user-attachments/assets/c377b612-b24c-467e-8c00-698c265b4761

