### PR TITLE
Fix: Corregir validación del formulario de registro de participantes

### DIFF
--- a/src/app/register/[organizerId]/[competitionId]/schemas/RegisterFormSchema.tsx
+++ b/src/app/register/[organizerId]/[competitionId]/schemas/RegisterFormSchema.tsx
@@ -4,17 +4,7 @@ import { RegisterFormSettings } from "@/types/competition";
 import { cleanRut, validateRut } from "@/utils/rut";
 
 export function createRegisterFormSchema(registerFormSettings: RegisterFormSettings) {
-  return z.object({
-    paymentFile: z.instanceof(File).optional().refine((file) => {
-      if (file instanceof File) {
-        return file.size > 0
-      } else if (file === null || file === undefined) {
-        return false
-      }
-      return true
-    }, {
-      message: 'Debes subir un comprobante de pago',
-    }),
+  const baseSchema = {
     ...Object.fromEntries(
       registerFormSettings.fields.map((field, index) => [
         `field_${index}`, 
@@ -36,7 +26,22 @@ export function createRegisterFormSchema(registerFormSettings: RegisterFormSetti
         message: 'RUT inválido',
       },
     ),
-  })
+  };
+
+  if (registerFormSettings.paymentRequired) {
+    return z.object({
+      ...baseSchema,
+      paymentFile: z.instanceof(File).refine((file) => 
+        file instanceof File && file.size > 0, {
+        message: 'Debes subir un comprobante de pago',
+      }),
+    });
+  }
+
+  return z.object({
+    ...baseSchema,
+    paymentFile: z.instanceof(File).optional(),
+  });
 }
 
 export type RegisterFormSchema = z.infer<ReturnType<typeof createRegisterFormSchema>>;


### PR DESCRIPTION
## Descripción 📝

Se corrige un problema crítico en el formulario de registro de participantes donde la validación del archivo de pago (`paymentFile`) impedía el envío del formulario incluso cuando el pago no era requerido.

## Problema Identificado

La validación en `RegisterFormSchema.tsx` siempre requería un archivo de pago válido, causando que:
- Los formularios de competencias gratuitas no se pudieran enviar
- La validación fallara con `return false` cuando `file` era `null` o `undefined`
- Los usuarios no pudieran completar el registro sin subir un comprobante

### Impacto del Fix

✅ **Solucionado:**
- El formulario de registro ahora se puede enviar correctamente
- La validación del `paymentFile` funciona apropiadamente
- Los usuarios pueden completar el proceso de registro

## Testing

- [ ] Probar registro en competencia gratuita
- [ ] Probar registro en competencia de pago con archivo
- [ ] Probar registro en competencia de pago sin archivo
- [ ] Verificar validación de RUT
- [ ] Verificar validación de campos personalizados

