### PR TITLE
fix: handle null register form settings in competition card

### DIFF
--- a/src/app/welcome/components/CompetitionCard.tsx
+++ b/src/app/welcome/components/CompetitionCard.tsx
@@ -83,7 +83,7 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
           
           <div className="flex items-center text-sm">
             <CurrencyDollar className="mr-2 size-4" />
-            <span>{registerFormSettings.paymentRequired ? formatCurrency(registerFormSettings.price as string) : 'Gratuito'}</span>
+            <span>{registerFormSettings?.paymentRequired ? formatCurrency(registerFormSettings.price as string) : 'Gratuito'}</span>
           </div>
         </div>
         
@@ -101,7 +101,7 @@ export default function CompetitionCard({ competition }: CompetitionCardProps) {
           </div>
         </div>
         
-        {competition.status === 'NOT_STARTED' && (
+        {competition.status === 'NOT_STARTED' && registerFormSettings && (
           <div className="card-actions mt-4 justify-start">
             <button
               className="btn btn-primary"


### PR DESCRIPTION
## Descripción 📝

Fix para el manejo de competencias sin formulario de registro configurado en la página de bienvenida. Previene errores de null reference y mejora la experiencia de usuario ocultando opciones no disponibles.

## Resumen de los cambios 🛠

### Problema Solucionado
- **Error de null reference**: `Cannot read properties of null (reading 'paymentRequired')` cuando una competencia recién creada no tiene formulario de registro
- **UX inconsistente**: Botón "Inscribirse" aparecía para competencias sin registro habilitado

### Cambios Implementados
- **Operador de encadenamiento opcional** (`?.`) en `registerFormSettings.paymentRequired` para evitar errores de null
- **Validación condicional** para mostrar botón "Inscribirse" solo cuando existe `registerFormSettings`

### Archivos Modificados
- `CompetitionCard.tsx` - Agregada validación de null safety y renderizado condicional

## Comentarios 💬

**Contexto**: Las competencias recién creadas no tienen formulario de registro configurado inmediatamente, causando errores al intentar acceder a propiedades de `registerFormSettings` que es `null`.

**Solución**: 
- Uso de optional chaining (`?.`) para acceso seguro a propiedades
- Renderizado condicional del botón "Inscribirse" basado en existencia del formulario

**Resultado**: 
- Eliminación de errores de runtime
- Mejor experiencia de usuario al ocultar opciones no disponibles
- Comportamiento consistente para competencias en diferentes estados de configuración

## Screenshots 📸
**ANTES:**
<img width="5103" height="1685" alt="image" src="https://github.com/user-attachments/assets/eebea294-83ff-4de6-8679-d1333a2b7cea" />

**DESPUÉS:**
<img width="4932" height="2209" alt="image" src="https://github.com/user-attachments/assets/7784ae31-02cd-4fce-91cb-c0ecff288af3" />
